### PR TITLE
keycache: authoritative MeshRadio pubkey resolver — decrypt firewall (Phase 66)

### DIFF
--- a/internal/app/fleet/cmd.go
+++ b/internal/app/fleet/cmd.go
@@ -15,6 +15,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/whereiskurt/meshtk/internal/keycache"
 	internal "github.com/whereiskurt/meshtk/internal/mqtt"
 	"github.com/whereiskurt/meshtk/pkg/otp"
 
@@ -44,6 +45,12 @@ type FleetCmd struct {
 	OTPUnlockMux    []sync.RWMutex          // Mutex to protect the OTPUnlocks map, per fleet
 	LyricsResponded []map[uint32]int        // Track which 'to' addresses have received lyrics responses, per fleet
 	LyricsRespMux   []sync.RWMutex          // Mutex to protect the LyricsResponded map, per fleet
+
+	// KeyResolver is the ONE process-wide authoritative pubkey resolver
+	// (internal/keycache, DDB MeshRadio) shared by EVERY fleet MqttClient — the
+	// fleet-wide generalization of crypto.go's pubKeyCache. Built once in
+	// NewFleets; nil if the store failed to build (falls back to nodes.json).
+	KeyResolver *keycache.KeyResolver
 }
 
 const BACKSTOP_GRACE_SEC = 30
@@ -69,7 +76,36 @@ func NewFleets(c *config.Config) (f *FleetCmd) {
 		}
 	}
 
+	f.KeyResolver = buildKeyResolver(c)
+
 	return f
+}
+
+// buildKeyResolver constructs the ONE shared authoritative pubkey resolver for
+// the whole fleet (mirrors server/cmd.go's credcache construction, but keycache
+// uses GetItem, and a shorter 60-120s TTL). Returns nil on store-build failure
+// so the fleet degrades to the nodes.json fallback rather than refusing to boot.
+func buildKeyResolver(c *config.Config) *keycache.KeyResolver {
+	kc := c.Server.KeyCache
+
+	cache, err := keycache.NewCache(kc.TTLSecs, kc.MaxSizeMB)
+	if err != nil {
+		c.Log.Errorf("keycache: failed to create pubkey cache (%v); falling back to nodes.json", err)
+		return nil
+	}
+
+	store, err := keycache.NewDynamoDBStore(kc.TableName, kc.TableRegion, kc.DynamoDBEndpoint)
+	if err != nil {
+		c.Log.Errorf("keycache: failed to create DynamoDB store (%v); falling back to nodes.json", err)
+		return nil
+	}
+
+	resolver := keycache.NewKeyResolver(cache, store,
+		keycache.WithNegativeTTL(time.Duration(kc.NegativeTTLSecs)*time.Second),
+	)
+	c.Log.Infof("keycache: authoritative pubkey resolver ready (table=%s region=%s ttl=%ds fallback=%q)",
+		kc.TableName, kc.TableRegion, kc.TTLSecs, kc.Fallback)
+	return resolver
 }
 func (f *FleetCmd) Help(cmd *cobra.Command, argz []string) {
 	f.CmdOutput.WasSuccess = true
@@ -87,7 +123,12 @@ func (f *FleetCmd) Simulate(cmd *cobra.Command, argz []string) {
 	for idx := range f.Config.Fleet {
 		f.initNodeDb(idx)
 		mqttClient := internal.NewMqttClient(f.Config, &f.Nodes[idx], f.FleetNodeHandler)
-		
+
+		// Thread the ONE shared authoritative pubkey resolver into every client so
+		// the whole fleet resolves decrypt/reply keys through a single cache
+		// (never per-client, never per-packet). Fallback governs miss behavior.
+		mqttClient.SetKeyResolver(f.KeyResolver, f.Config.Server.KeyCache.Fallback)
+
 		// Set up ACK handler for this fleet member
 		fleetIdx := idx // Capture idx for closure
 		mqttClient.SetAckHandler(func(to, from uint32, requestId uint32) {
@@ -220,9 +261,12 @@ func (n *FleetCmd) sendPKIReply(toFleetIdx int, to, from uint32, topic string, r
 	// The 'to' node (receiver of original message) is now the sender of the reply
 	senderPrivKey := toNode.PrivKey
 
-	senderPubKeyHex, err := n.MqttClient[toFleetIdx].FetchPublicKeyFromDefcon(from)
+	// Reply-encrypt recipient key MUST come from the same authoritative resolver
+	// as the decrypt site (crypto.go). Migrating only decrypt would encrypt replies
+	// to a stale/poisoned nodes.json key (landmine L4).
+	senderPubKeyHex, err := n.MqttClient[toFleetIdx].ResolveSenderPubKey(from)
 	if err != nil {
-		n.Config.Log.Errorf("failed to fetch sender public key from DEFCON API: %v", err)
+		n.Config.Log.Errorf("failed to resolve recipient public key: %v", err)
 		return
 	}
 

--- a/internal/keycache/cache.go
+++ b/internal/keycache/cache.go
@@ -1,0 +1,135 @@
+package keycache
+
+import (
+	"sort"
+	"time"
+
+	"github.com/maypok86/otter/v2"
+	"github.com/maypok86/otter/v2/stats"
+)
+
+// CacheStats holds cache performance statistics.
+type CacheStats struct {
+	Hits      uint64
+	Misses    uint64
+	Evictions uint64
+	HitRate   float64
+}
+
+// Cache wraps an Otter v2 cache for typed pubkey access, keyed by the canonical
+// nodeId string ("!%08x"). Mirrors credcache.Cache but stores *Key values.
+type Cache struct {
+	inner   *otter.Cache[string, *Key]
+	counter *stats.Counter
+}
+
+// NewCache creates a new pubkey cache with the given TTL (seconds) and approximate
+// max size (MB). maxSizeMB is converted to an approximate entry count (~100 bytes
+// per key). For keycache the TTL is 60-120s (plain expiry, NOT credcache's 900s).
+func NewCache(ttlSecs int, maxSizeMB int) (*Cache, error) {
+	counter := stats.NewCounter()
+	// Approximate: ~100 bytes per key, so 1 MB ~ 10,000 entries
+	maxEntries := maxSizeMB * 10000
+	if maxEntries < 100 {
+		maxEntries = 100
+	}
+
+	inner, err := otter.New[string, *Key](&otter.Options[string, *Key]{
+		MaximumSize:      maxEntries,
+		ExpiryCalculator: otter.ExpiryWriting[string, *Key](time.Duration(ttlSecs) * time.Second),
+		StatsRecorder:    counter,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return &Cache{
+		inner:   inner,
+		counter: counter,
+	}, nil
+}
+
+// Get retrieves a key by nodeId. Returns nil, false on cache miss.
+func (c *Cache) Get(nodeID string) (*Key, bool) {
+	return c.inner.GetIfPresent(nodeID)
+}
+
+// Set stores a key in the cache keyed by nodeId.
+func (c *Cache) Set(nodeID string, key *Key) {
+	c.inner.Set(nodeID, key)
+}
+
+// Delete removes a key from the cache.
+func (c *Cache) Delete(nodeID string) {
+	c.inner.Invalidate(nodeID)
+}
+
+// Stats returns a snapshot of cache performance statistics.
+func (c *Cache) Stats() CacheStats {
+	s := c.inner.Stats()
+	return CacheStats{
+		Hits:      s.Hits,
+		Misses:    s.Misses,
+		Evictions: s.Evictions,
+		HitRate:   s.HitRatio(),
+	}
+}
+
+// Size returns the approximate number of entries in the cache.
+func (c *Cache) Size() int {
+	return c.inner.EstimatedSize()
+}
+
+// CacheEntry represents a single cache entry for admin listing.
+type CacheEntry struct {
+	NodeID       string `json:"node_id"`
+	TTLRemaining int    `json:"ttl_remaining"`
+	Negative     bool   `json:"negative"`
+}
+
+// SetWithTTL stores a key with a custom TTL duration (used for negative entries).
+func (c *Cache) SetWithTTL(nodeID string, key *Key, ttl time.Duration) {
+	c.inner.Set(nodeID, key)
+	c.inner.SetExpiresAfter(nodeID, ttl)
+}
+
+// DeleteAll invalidates all cache entries, returning the approximate count evicted.
+func (c *Cache) DeleteAll() int {
+	count := c.inner.EstimatedSize()
+	c.inner.InvalidateAll()
+	return count
+}
+
+// Entries returns all cache entries sorted by TTL remaining (ascending).
+// Returns an empty slice (not nil) when the cache is empty.
+func (c *Cache) Entries() []CacheEntry {
+	entries := make([]CacheEntry, 0)
+
+	for nodeID := range c.inner.All() {
+		entry, ok := c.inner.GetEntryQuietly(nodeID)
+		if !ok {
+			continue
+		}
+		expiresAt := time.Unix(0, entry.ExpiresAtNano)
+		ttl := int(time.Until(expiresAt).Seconds())
+		if ttl < 0 {
+			ttl = 0
+		}
+		entries = append(entries, CacheEntry{
+			NodeID:       nodeID,
+			TTLRemaining: ttl,
+			Negative:     entry.Value.Negative,
+		})
+	}
+
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].TTLRemaining < entries[j].TTLRemaining
+	})
+
+	return entries
+}
+
+// Close stops all cache goroutines and releases resources.
+func (c *Cache) Close() {
+	c.inner.StopAllGoroutines()
+}

--- a/internal/keycache/key_parity_test.go
+++ b/internal/keycache/key_parity_test.go
@@ -1,0 +1,61 @@
+package keycache
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+)
+
+// TestKeyParity is the Go twin of run.human's mesh-radio-key-parity.test.ts
+// (sibling of qr-key-parity.test.ts). It LOCKS meshtk's composed GetItem key to
+// the byte-identical ElectroDB MeshRadio primary key. Any drift in entity name,
+// version, service, or nodeId canonicalization silently 404s every decrypt
+// (RESEARCH.md landmine L1) — this test fails first.
+//
+// ElectroDB v3.5 format for MeshRadio keyed by nodeId:
+//   pk = "$run#nodeid_<nodeId>"   sk = "$meshradio_1"
+// For nodeNum 0x433d1cec, nodeId canonicalizes to "!433d1cec".
+func TestKeyParity_MeshRadioComposedKey(t *testing.T) {
+	const nodeNum = uint32(0x433d1cec)
+
+	const wantNodeID = "!433d1cec"
+	const wantPK = "$run#nodeid_!433d1cec"
+	const wantSK = "$meshradio_1"
+
+	if got := NodeIDFromNum(nodeNum); got != wantNodeID {
+		t.Errorf("NodeIDFromNum(%#x) = %q, want %q", nodeNum, got, wantNodeID)
+	}
+
+	key := meshRadioKey(nodeNum)
+
+	pk, ok := key["pk"].(*types.AttributeValueMemberS)
+	if !ok {
+		t.Fatalf("key[pk] type = %T, want *AttributeValueMemberS", key["pk"])
+	}
+	if pk.Value != wantPK {
+		t.Errorf("pk = %q, want %q", pk.Value, wantPK)
+	}
+
+	sk, ok := key["sk"].(*types.AttributeValueMemberS)
+	if !ok {
+		t.Fatalf("key[sk] type = %T, want *AttributeValueMemberS", key["sk"])
+	}
+	if sk.Value != wantSK {
+		t.Errorf("sk = %q, want %q", sk.Value, wantSK)
+	}
+}
+
+// TestKeyParity_PadsLeadingZeroNodeNum guards RESEARCH.md landmine L2: a nodeNum
+// with leading-zero bytes must pad to 8 lowercase hex digits, matching the
+// run.human write boundary's "!" + toString(16).padStart(8,"0").
+func TestKeyParity_PadsLeadingZeroNodeNum(t *testing.T) {
+	if got := NodeIDFromNum(0x00000abc); got != "!00000abc" {
+		t.Errorf("NodeIDFromNum(0x00000abc) = %q, want %q", got, "!00000abc")
+	}
+	if got := NodeIDFromNum(0x00000001); got != "!00000001" {
+		t.Errorf("NodeIDFromNum(0x1) = %q, want %q", got, "!00000001")
+	}
+	if got := NodeIDFromNum(0xffffffff); got != "!ffffffff" {
+		t.Errorf("NodeIDFromNum(0xffffffff) = %q, want %q", got, "!ffffffff")
+	}
+}

--- a/internal/keycache/resolver.go
+++ b/internal/keycache/resolver.go
@@ -1,0 +1,183 @@
+package keycache
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"sync/atomic"
+	"time"
+
+	"golang.org/x/sync/singleflight"
+)
+
+// KeyResolver resolves a sender node's authoritative decrypt pubkey using a cache,
+// a KeyStore (DynamoDB GetItem), singleflight for deduplication, and a circuit
+// breaker for store degradation. It mirrors credcache.CacheAuthenticator.
+//
+// ONE KeyResolver is shared process-wide across the entire ghost fleet (the
+// fleet-wide generalization of crypto.go's pubKeyCache sync.Map). It is the
+// load-bounded key source: cache-first, at most ~one DDB read per node per TTL,
+// independent of packet/client volume — never per-packet, never per-client.
+type KeyResolver struct {
+	cache *Cache
+	store KeyStore
+	sf    singleflight.Group
+
+	// Circuit breaker state (all accessed atomically).
+	consecutiveFailures atomic.Int64
+	lastFailure         atomic.Int64 // unix nanoseconds
+	failureThreshold    int64
+	cooldownDuration    time.Duration
+
+	// Negative caching TTL for unknown (unenrolled) senders.
+	negativeTTL time.Duration
+}
+
+// ResolverOption configures a KeyResolver.
+type ResolverOption func(*KeyResolver)
+
+// WithFailureThreshold sets the number of consecutive store failures before
+// the circuit breaker trips.
+func WithFailureThreshold(n int64) ResolverOption {
+	return func(r *KeyResolver) {
+		r.failureThreshold = n
+	}
+}
+
+// WithCooldownDuration sets the duration after which the circuit breaker
+// allows a retry after tripping.
+func WithCooldownDuration(d time.Duration) ResolverOption {
+	return func(r *KeyResolver) {
+		r.cooldownDuration = d
+	}
+}
+
+// WithNegativeTTL sets the TTL for negative cache entries (unknown senders).
+func WithNegativeTTL(d time.Duration) ResolverOption {
+	return func(r *KeyResolver) {
+		r.negativeTTL = d
+	}
+}
+
+// NewKeyResolver creates a KeyResolver with the given cache and store.
+// Defaults mirror credcache: failureThreshold=3, cooldownDuration=10s,
+// negativeTTL=60s. The positive-entry TTL is owned by the cache (NewCache,
+// 60-120s), NOT credcache's 900s.
+func NewKeyResolver(cache *Cache, store KeyStore, opts ...ResolverOption) *KeyResolver {
+	r := &KeyResolver{
+		cache:            cache,
+		store:            store,
+		failureThreshold: 3,
+		cooldownDuration: 10 * time.Second,
+		negativeTTL:      60 * time.Second,
+	}
+	for _, opt := range opts {
+		opt(r)
+	}
+	return r
+}
+
+// Resolve returns the sender node's 0x-hex pubkey, cache-first.
+//   - cache hit (positive) → (hex, true, nil)
+//   - cache hit (negative) → ("", false, nil), no store call
+//   - cache miss → singleflight fetch; ErrNotFound negative-caches and returns
+//     ("", false, nil); store error returns ("", false, err)
+//
+// A miss (ok=false, err=nil) is the caller's cue to apply the fallback flag
+// (nodes.json bring-up) or NACK (fallback=none, poisoning-resistant).
+func (r *KeyResolver) Resolve(ctx context.Context, nodeNum uint32) (string, bool, error) {
+	if nodeNum == 0 {
+		return "", false, nil
+	}
+
+	nodeID := NodeIDFromNum(nodeNum)
+
+	// Try cache first.
+	if key, ok := r.cache.Get(nodeID); ok {
+		if key.Negative {
+			return "", false, nil
+		}
+		return key.PubKeyHex, true, nil
+	}
+
+	// Cache miss: fetch via singleflight.
+	key, err := r.fetchWithSingleflight(ctx, nodeNum, nodeID)
+	if err != nil {
+		return "", false, err
+	}
+	if key == nil {
+		return "", false, nil
+	}
+	return key.PubKeyHex, true, nil
+}
+
+// fetchWithSingleflight wraps store.Fetch with singleflight deduplication and
+// circuit breaker logic. Concurrent misses for the same node collapse to one
+// store call.
+func (r *KeyResolver) fetchWithSingleflight(ctx context.Context, nodeNum uint32, nodeID string) (*Key, error) {
+	if r.IsDegraded() {
+		return nil, fmt.Errorf("dynamodb circuit breaker open")
+	}
+
+	v, err, _ := r.sf.Do(nodeID, func() (interface{}, error) {
+		key, err := r.store.Fetch(ctx, nodeNum)
+		if err != nil {
+			if errors.Is(err, ErrNotFound) {
+				// Unknown sender: negative-cache to bound DDB reads for
+				// unenrolled nodes over the negativeTTL window.
+				negKey := &Key{NodeID: nodeID, NodeNum: nodeNum, Negative: true}
+				r.cache.SetWithTTL(nodeID, negKey, r.negativeTTL)
+				return nil, nil
+			}
+			r.recordFailure()
+			return nil, err
+		}
+		r.recordSuccess()
+		r.cache.Set(nodeID, key)
+		return key, nil
+	})
+
+	if err != nil {
+		return nil, err
+	}
+	if v == nil {
+		return nil, nil
+	}
+	return v.(*Key), nil
+}
+
+// ResetCircuitBreaker resets the consecutive failure counter to zero.
+// Used by admin API to manually recover from degraded state.
+func (r *KeyResolver) ResetCircuitBreaker() {
+	prev := r.consecutiveFailures.Swap(0)
+	if prev > 0 {
+		log.Printf("[INFO] keycache circuit breaker reset by admin (was at %d consecutive failures)", prev)
+	}
+}
+
+// IsDegraded returns true when the circuit breaker is open.
+func (r *KeyResolver) IsDegraded() bool {
+	failures := r.consecutiveFailures.Load()
+	if failures < r.failureThreshold {
+		return false
+	}
+	lastFail := time.Unix(0, r.lastFailure.Load())
+	return time.Since(lastFail) < r.cooldownDuration
+}
+
+// recordFailure increments the consecutive failure counter and records the
+// failure timestamp.
+func (r *KeyResolver) recordFailure() {
+	r.consecutiveFailures.Add(1)
+	r.lastFailure.Store(time.Now().UnixNano())
+}
+
+// recordSuccess resets the failure counter. Logs restoration if recovering
+// from failures.
+func (r *KeyResolver) recordSuccess() {
+	prev := r.consecutiveFailures.Swap(0)
+	if prev > 0 {
+		log.Printf("[INFO] keycache DynamoDB connectivity restored (was at %d consecutive failures)", prev)
+	}
+}

--- a/internal/keycache/resolver_test.go
+++ b/internal/keycache/resolver_test.go
@@ -1,0 +1,341 @@
+package keycache
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// mockStore implements KeyStore for testing, keyed by uint32 nodeNum.
+type mockStore struct {
+	mu        sync.Mutex
+	keys      map[uint32]*Key
+	err       error
+	callCount atomic.Int64
+	// delay lets tests widen the singleflight window deterministically.
+	delay time.Duration
+}
+
+func newMockStore() *mockStore {
+	return &mockStore{keys: make(map[uint32]*Key)}
+}
+
+func (m *mockStore) Fetch(ctx context.Context, nodeNum uint32) (*Key, error) {
+	m.callCount.Add(1)
+	if m.delay > 0 {
+		time.Sleep(m.delay)
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.err != nil {
+		return nil, m.err
+	}
+	key, ok := m.keys[nodeNum]
+	if !ok {
+		return nil, ErrNotFound
+	}
+	return key, nil
+}
+
+func (m *mockStore) setKey(nodeNum uint32, key *Key) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.keys[nodeNum] = key
+}
+
+func (m *mockStore) setError(err error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.err = err
+}
+
+func (m *mockStore) calls() int64 { return m.callCount.Load() }
+
+func newTestCache(t *testing.T) *Cache {
+	t.Helper()
+	c, err := NewCache(90, 1) // 90s TTL, 1MB
+	if err != nil {
+		t.Fatalf("NewCache() error = %v", err)
+	}
+	t.Cleanup(c.Close)
+	return c
+}
+
+const sampleHex = "0x433d1cec00112233445566778899aabbccddeeff00112233445566778899aabb"
+
+func TestResolve_CacheHit_NoStoreCall(t *testing.T) {
+	cache := newTestCache(t)
+	store := newMockStore()
+
+	nodeNum := uint32(0x433d1cec)
+	cache.Set(NodeIDFromNum(nodeNum), &Key{NodeID: NodeIDFromNum(nodeNum), NodeNum: nodeNum, PubKeyHex: sampleHex})
+
+	r := NewKeyResolver(cache, store)
+
+	hex, ok, err := r.Resolve(context.Background(), nodeNum)
+	if err != nil {
+		t.Fatalf("Resolve() error = %v", err)
+	}
+	if !ok {
+		t.Fatal("Resolve() ok = false, want true for cached key")
+	}
+	if hex != sampleHex {
+		t.Errorf("Resolve() hex = %q, want %q", hex, sampleHex)
+	}
+	if store.calls() != 0 {
+		t.Errorf("store.Fetch called %d times, want 0 (cache hit)", store.calls())
+	}
+}
+
+func TestResolve_CacheMiss_FetchAndPopulate(t *testing.T) {
+	cache := newTestCache(t)
+	store := newMockStore()
+	nodeNum := uint32(0x433d1cec)
+	store.setKey(nodeNum, &Key{PubKeyHex: sampleHex})
+
+	r := NewKeyResolver(cache, store)
+
+	hex, ok, err := r.Resolve(context.Background(), nodeNum)
+	if err != nil {
+		t.Fatalf("Resolve() error = %v", err)
+	}
+	if !ok || hex != sampleHex {
+		t.Fatalf("Resolve() = (%q, %v), want (%q, true)", hex, ok, sampleHex)
+	}
+	if store.calls() != 1 {
+		t.Errorf("store.Fetch called %d times, want 1", store.calls())
+	}
+
+	// Cache populated: second call hits cache, no further store call.
+	if _, ok := cache.Get(NodeIDFromNum(nodeNum)); !ok {
+		t.Fatal("cache should contain node after fetch")
+	}
+	_, _, _ = r.Resolve(context.Background(), nodeNum)
+	if store.calls() != 1 {
+		t.Errorf("store.Fetch called %d times after cache populate, want still 1", store.calls())
+	}
+}
+
+func TestResolve_EmptyNodeNum(t *testing.T) {
+	cache := newTestCache(t)
+	store := newMockStore()
+	r := NewKeyResolver(cache, store)
+
+	hex, ok, err := r.Resolve(context.Background(), 0)
+	if err != nil {
+		t.Fatalf("Resolve() error = %v", err)
+	}
+	if ok || hex != "" {
+		t.Fatalf("Resolve(0) = (%q, %v), want (\"\", false)", hex, ok)
+	}
+	if store.calls() != 0 {
+		t.Errorf("store.Fetch called %d times for nodeNum 0, want 0", store.calls())
+	}
+}
+
+func TestResolve_NegativeCache_UnknownSenderBoundsReads(t *testing.T) {
+	cache := newTestCache(t)
+	store := newMockStore() // no keys → ErrNotFound
+	r := NewKeyResolver(cache, store)
+
+	nodeNum := uint32(0xdeadbeef)
+
+	// First lookup: one store call, negative-cached.
+	hex, ok, err := r.Resolve(context.Background(), nodeNum)
+	if err != nil {
+		t.Fatalf("Resolve() error = %v", err)
+	}
+	if ok || hex != "" {
+		t.Fatalf("Resolve() = (%q, %v), want miss", hex, ok)
+	}
+	if store.calls() != 1 {
+		t.Fatalf("store.Fetch called %d times on first miss, want 1", store.calls())
+	}
+
+	// Subsequent lookups served from negative entry — no further store calls.
+	for i := 0; i < 5; i++ {
+		_, ok, err := r.Resolve(context.Background(), nodeNum)
+		if err != nil || ok {
+			t.Fatalf("Resolve() repeat = (ok=%v, err=%v), want miss", ok, err)
+		}
+	}
+	if store.calls() != 1 {
+		t.Errorf("store.Fetch called %d times after negative cache, want still 1", store.calls())
+	}
+}
+
+func TestResolve_NegativeCache_PreExisting_NoStoreCall(t *testing.T) {
+	cache := newTestCache(t)
+	store := newMockStore()
+	nodeNum := uint32(0x00000abc)
+	cache.Set(NodeIDFromNum(nodeNum), &Key{NodeID: NodeIDFromNum(nodeNum), NodeNum: nodeNum, Negative: true})
+
+	r := NewKeyResolver(cache, store)
+
+	_, ok, err := r.Resolve(context.Background(), nodeNum)
+	if err != nil {
+		t.Fatalf("Resolve() error = %v", err)
+	}
+	if ok {
+		t.Fatal("Resolve() ok = true, want false for negative cache entry")
+	}
+	if store.calls() != 0 {
+		t.Errorf("store.Fetch called %d times, want 0 (negative cache hit)", store.calls())
+	}
+}
+
+func TestResolve_Singleflight_CollapsesConcurrentMisses(t *testing.T) {
+	cache := newTestCache(t)
+	store := newMockStore()
+	store.delay = 50 * time.Millisecond // widen the singleflight window
+	nodeNum := uint32(0x433d1cec)
+	store.setKey(nodeNum, &Key{PubKeyHex: sampleHex})
+
+	r := NewKeyResolver(cache, store)
+
+	const concurrency = 20
+	var wg sync.WaitGroup
+	results := make([]bool, concurrency)
+	errs := make([]error, concurrency)
+
+	wg.Add(concurrency)
+	for i := 0; i < concurrency; i++ {
+		go func(idx int) {
+			defer wg.Done()
+			_, ok, err := r.Resolve(context.Background(), nodeNum)
+			results[idx] = ok
+			errs[idx] = err
+		}(i)
+	}
+	wg.Wait()
+
+	for i, err := range errs {
+		if err != nil {
+			t.Errorf("goroutine %d: Resolve() error = %v", i, err)
+		}
+	}
+	for i, ok := range results {
+		if !ok {
+			t.Errorf("goroutine %d: Resolve() ok = false, want true", i)
+		}
+	}
+	if calls := store.calls(); calls != 1 {
+		t.Errorf("store.Fetch called %d times, want exactly 1 (singleflight collapse)", calls)
+	}
+}
+
+func TestResolve_CircuitBreaker_OpensAndShortCircuits(t *testing.T) {
+	cache := newTestCache(t)
+	store := newMockStore()
+	store.setError(errors.New("dynamodb timeout"))
+
+	r := NewKeyResolver(cache, store,
+		WithFailureThreshold(2),
+		WithCooldownDuration(5*time.Second),
+	)
+
+	// First 2 misses attempt the store and fail.
+	for i := 0; i < 2; i++ {
+		if _, _, err := r.Resolve(context.Background(), uint32(0x1000+i)); err == nil {
+			t.Fatalf("call %d: Resolve() error = nil, want error", i)
+		}
+	}
+	if store.calls() != 2 {
+		t.Fatalf("store.Fetch called %d times before trip, want 2", store.calls())
+	}
+	if !r.IsDegraded() {
+		t.Fatal("IsDegraded() = false after threshold failures, want true")
+	}
+
+	// Third call short-circuits without hitting the store.
+	if _, _, err := r.Resolve(context.Background(), uint32(0x2000)); err == nil {
+		t.Fatal("Resolve() error = nil, want circuit breaker error")
+	}
+	if store.calls() != 2 {
+		t.Errorf("store.Fetch called %d times after trip, want still 2", store.calls())
+	}
+}
+
+func TestResolve_CircuitBreaker_RecoversAfterCooldown(t *testing.T) {
+	cache := newTestCache(t)
+	store := newMockStore()
+	store.setError(errors.New("dynamodb timeout"))
+
+	r := NewKeyResolver(cache, store,
+		WithFailureThreshold(2),
+		WithCooldownDuration(50*time.Millisecond),
+	)
+
+	for i := 0; i < 2; i++ {
+		_, _, _ = r.Resolve(context.Background(), uint32(0x3000+i))
+	}
+	time.Sleep(100 * time.Millisecond)
+
+	store.setError(nil)
+	nodeNum := uint32(0x433d1cec)
+	store.setKey(nodeNum, &Key{PubKeyHex: sampleHex})
+
+	hex, ok, err := r.Resolve(context.Background(), nodeNum)
+	if err != nil {
+		t.Fatalf("Resolve() after recovery error = %v", err)
+	}
+	if !ok || hex != sampleHex {
+		t.Fatalf("Resolve() after recovery = (%q, %v), want (%q, true)", hex, ok, sampleHex)
+	}
+}
+
+func TestResolve_CacheHitsDuringDegradedMode(t *testing.T) {
+	cache := newTestCache(t)
+	store := newMockStore()
+	nodeNum := uint32(0x433d1cec)
+	cache.Set(NodeIDFromNum(nodeNum), &Key{NodeID: NodeIDFromNum(nodeNum), NodeNum: nodeNum, PubKeyHex: sampleHex})
+
+	r := NewKeyResolver(cache, store,
+		WithFailureThreshold(2),
+		WithCooldownDuration(5*time.Second),
+	)
+
+	store.setError(errors.New("dynamodb down"))
+	for i := 0; i < 2; i++ {
+		_, _, _ = r.Resolve(context.Background(), uint32(0x4000+i))
+	}
+	if !r.IsDegraded() {
+		t.Fatal("IsDegraded() = false, want true after tripping")
+	}
+
+	// Cache hit still succeeds while the breaker is open.
+	hex, ok, err := r.Resolve(context.Background(), nodeNum)
+	if err != nil {
+		t.Fatalf("Resolve() cache hit during degraded mode error = %v", err)
+	}
+	if !ok || hex != sampleHex {
+		t.Fatalf("Resolve() cache hit during degraded = (%q, %v), want (%q, true)", hex, ok, sampleHex)
+	}
+}
+
+func TestResolve_ResetCircuitBreaker(t *testing.T) {
+	cache := newTestCache(t)
+	store := newMockStore()
+	store.setError(errors.New("dynamodb timeout"))
+
+	r := NewKeyResolver(cache, store,
+		WithFailureThreshold(2),
+		WithCooldownDuration(5*time.Second),
+	)
+
+	for i := 0; i < 2; i++ {
+		_, _, _ = r.Resolve(context.Background(), uint32(0x5000+i))
+	}
+	if !r.IsDegraded() {
+		t.Fatal("IsDegraded() = false, want true")
+	}
+
+	r.ResetCircuitBreaker()
+	if r.IsDegraded() {
+		t.Fatal("IsDegraded() = true after reset, want false")
+	}
+}

--- a/internal/keycache/store.go
+++ b/internal/keycache/store.go
@@ -1,0 +1,109 @@
+package keycache
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+)
+
+// DynamoDBAPI is the subset of DynamoDB client methods used by DynamoDBStore.
+// The ONE deliberate divergence from credcache: keycache uses GetItem, never Scan.
+type DynamoDBAPI interface {
+	GetItem(ctx context.Context, params *dynamodb.GetItemInput, optFns ...func(*dynamodb.Options)) (*dynamodb.GetItemOutput, error)
+}
+
+// DynamoDBStore implements KeyStore using a direct DynamoDB GetItem by the
+// byte-identical ElectroDB MeshRadio primary key. This bounds DDB load to one
+// point read per node per TTL (never a Scan, never per-packet).
+type DynamoDBStore struct {
+	client    DynamoDBAPI
+	tableName string
+}
+
+// NewDynamoDBStore creates a DynamoDBStore with a real AWS DynamoDB client.
+// If endpoint is non-empty, it overrides the default endpoint (for local dev).
+func NewDynamoDBStore(tableName, region, endpoint string) (*DynamoDBStore, error) {
+	cfg, err := config.LoadDefaultConfig(context.TODO())
+	if err != nil {
+		return nil, fmt.Errorf("load aws config: %w", err)
+	}
+
+	opts := []func(*dynamodb.Options){
+		func(o *dynamodb.Options) {
+			o.Region = region
+		},
+	}
+	if endpoint != "" {
+		opts = append(opts, func(o *dynamodb.Options) {
+			o.BaseEndpoint = aws.String(endpoint)
+		})
+	}
+
+	client := dynamodb.NewFromConfig(cfg, opts...)
+	return &DynamoDBStore{
+		client:    client,
+		tableName: tableName,
+	}, nil
+}
+
+// NewDynamoDBStoreWithClient creates a DynamoDBStore with a provided client (for testing).
+func NewDynamoDBStoreWithClient(client DynamoDBAPI, tableName string) *DynamoDBStore {
+	return &DynamoDBStore{
+		client:    client,
+		tableName: tableName,
+	}
+}
+
+// NodeIDFromNum composes the canonical nodeId string ("!" + lowercase hex padded
+// to 8) from a uint32 nodeNum — byte-identical to run.human's MeshRadio write.
+func NodeIDFromNum(nodeNum uint32) string {
+	return fmt.Sprintf("!%08x", nodeNum)
+}
+
+// meshRadioKey composes the byte-identical ElectroDB MeshRadio primary key for a
+// nodeNum. ElectroDB v3.5 format: pk="$run#nodeid_<nodeId>", sk="$meshradio_1".
+// This composition is LOCKED by key_parity_test.go against run.human's parity test.
+func meshRadioKey(nodeNum uint32) map[string]types.AttributeValue {
+	nodeID := NodeIDFromNum(nodeNum)
+	return map[string]types.AttributeValue{
+		"pk": &types.AttributeValueMemberS{Value: "$run#nodeid_" + nodeID},
+		"sk": &types.AttributeValueMemberS{Value: "$meshradio_1"},
+	}
+}
+
+// Fetch performs a direct GetItem on the MeshRadio item for the given nodeNum.
+// It projects publicKey and nodeNum. Returns ErrNotFound when the item is absent.
+// The returned Key.PubKeyHex is already 0x hex (ready for ParseHexKey).
+func (s *DynamoDBStore) Fetch(ctx context.Context, nodeNum uint32) (*Key, error) {
+	input := &dynamodb.GetItemInput{
+		TableName:            aws.String(s.tableName),
+		Key:                  meshRadioKey(nodeNum),
+		ProjectionExpression: aws.String("publicKey, nodeNum"),
+	}
+
+	result, err := s.client.GetItem(ctx, input)
+	if err != nil {
+		return nil, fmt.Errorf("dynamodb getitem: %w", err)
+	}
+
+	if len(result.Item) == 0 {
+		return nil, ErrNotFound
+	}
+
+	var key Key
+	if err := attributevalue.UnmarshalMap(result.Item, &key); err != nil {
+		return nil, fmt.Errorf("unmarshal key: %w", err)
+	}
+	// nodeNum may be absent from a legacy row; fall back to the requested value
+	// and always stamp the canonical nodeId for cache keying/inspection.
+	if key.NodeNum == 0 {
+		key.NodeNum = nodeNum
+	}
+	key.NodeID = NodeIDFromNum(nodeNum)
+	return &key, nil
+}

--- a/internal/keycache/store_test.go
+++ b/internal/keycache/store_test.go
@@ -1,0 +1,135 @@
+package keycache
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+)
+
+// mockDynamoDBClient implements DynamoDBAPI for testing (GetItem, never Scan).
+type mockDynamoDBClient struct {
+	getOutput *dynamodb.GetItemOutput
+	getError  error
+	// captured holds the last GetItemInput for inspection.
+	captured *dynamodb.GetItemInput
+}
+
+func (m *mockDynamoDBClient) GetItem(ctx context.Context, params *dynamodb.GetItemInput, optFns ...func(*dynamodb.Options)) (*dynamodb.GetItemOutput, error) {
+	m.captured = params
+	if m.getError != nil {
+		return nil, m.getError
+	}
+	return m.getOutput, nil
+}
+
+func TestStoreFetchKnownNode(t *testing.T) {
+	item := map[string]types.AttributeValue{
+		"publicKey": &types.AttributeValueMemberS{Value: sampleHex},
+		"nodeNum":   &types.AttributeValueMemberN{Value: "1128078572"}, // 0x433d1cec
+	}
+
+	mock := &mockDynamoDBClient{getOutput: &dynamodb.GetItemOutput{Item: item}}
+
+	store := NewDynamoDBStoreWithClient(mock, "run-human-electro")
+	got, err := store.Fetch(context.Background(), 0x433d1cec)
+	if err != nil {
+		t.Fatalf("Fetch() error = %v", err)
+	}
+	if got.PubKeyHex != sampleHex {
+		t.Errorf("PubKeyHex = %q, want %q", got.PubKeyHex, sampleHex)
+	}
+	if got.NodeNum != 0x433d1cec {
+		t.Errorf("NodeNum = %#x, want %#x", got.NodeNum, uint32(0x433d1cec))
+	}
+	if got.NodeID != "!433d1cec" {
+		t.Errorf("NodeID = %q, want %q", got.NodeID, "!433d1cec")
+	}
+}
+
+func TestStoreFetchUnknownNode(t *testing.T) {
+	// Empty Item map → ErrNotFound.
+	mock := &mockDynamoDBClient{getOutput: &dynamodb.GetItemOutput{Item: map[string]types.AttributeValue{}}}
+
+	store := NewDynamoDBStoreWithClient(mock, "run-human-electro")
+	_, err := store.Fetch(context.Background(), 0xdeadbeef)
+	if err == nil {
+		t.Fatal("Fetch() should return error for unknown node")
+	}
+	if !errors.Is(err, ErrNotFound) {
+		t.Errorf("Fetch() error = %v, want ErrNotFound", err)
+	}
+}
+
+func TestStoreFetchNilItem(t *testing.T) {
+	// GetItem with no match returns a nil Item map → ErrNotFound.
+	mock := &mockDynamoDBClient{getOutput: &dynamodb.GetItemOutput{Item: nil}}
+
+	store := NewDynamoDBStoreWithClient(mock, "run-human-electro")
+	_, err := store.Fetch(context.Background(), 0x433d1cec)
+	if !errors.Is(err, ErrNotFound) {
+		t.Errorf("Fetch() error = %v, want ErrNotFound for nil item", err)
+	}
+}
+
+func TestStoreFetchErrorPropagation(t *testing.T) {
+	expectedErr := errors.New("dynamodb connection failed")
+	mock := &mockDynamoDBClient{getError: expectedErr}
+
+	store := NewDynamoDBStoreWithClient(mock, "run-human-electro")
+	_, err := store.Fetch(context.Background(), 0x433d1cec)
+	if err == nil {
+		t.Fatal("Fetch() should propagate error")
+	}
+	if !errors.Is(err, expectedErr) {
+		t.Errorf("Fetch() error = %v, want wrapped %v", err, expectedErr)
+	}
+}
+
+func TestStoreFetchComposesKeyAndProjection(t *testing.T) {
+	mock := &mockDynamoDBClient{getOutput: &dynamodb.GetItemOutput{Item: map[string]types.AttributeValue{}}}
+
+	store := NewDynamoDBStoreWithClient(mock, "run-human-electro")
+	_, _ = store.Fetch(context.Background(), 0x433d1cec)
+
+	if mock.captured == nil {
+		t.Fatal("GetItem was not called")
+	}
+	if mock.captured.TableName == nil || *mock.captured.TableName != "run-human-electro" {
+		t.Errorf("TableName = %v, want run-human-electro", mock.captured.TableName)
+	}
+
+	pk, ok := mock.captured.Key["pk"].(*types.AttributeValueMemberS)
+	if !ok || pk.Value != "$run#nodeid_!433d1cec" {
+		t.Errorf("Key[pk] = %#v, want S \"$run#nodeid_!433d1cec\"", mock.captured.Key["pk"])
+	}
+	sk, ok := mock.captured.Key["sk"].(*types.AttributeValueMemberS)
+	if !ok || sk.Value != "$meshradio_1" {
+		t.Errorf("Key[sk] = %#v, want S \"$meshradio_1\"", mock.captured.Key["sk"])
+	}
+
+	if mock.captured.ProjectionExpression == nil {
+		t.Fatal("ProjectionExpression should not be nil")
+	}
+	if *mock.captured.ProjectionExpression != "publicKey, nodeNum" {
+		t.Errorf("ProjectionExpression = %q, want %q", *mock.captured.ProjectionExpression, "publicKey, nodeNum")
+	}
+}
+
+// TestStoreUnmarshalsPublicKey confirms the 0x-hex publicKey attribute round-trips
+// through attributevalue into Key.PubKeyHex (the value ParseHexKey consumes).
+func TestStoreUnmarshalsPublicKey(t *testing.T) {
+	var k Key
+	item := map[string]types.AttributeValue{
+		"publicKey": &types.AttributeValueMemberS{Value: sampleHex},
+	}
+	if err := attributevalue.UnmarshalMap(item, &k); err != nil {
+		t.Fatalf("UnmarshalMap() error = %v", err)
+	}
+	if k.PubKeyHex != sampleHex {
+		t.Errorf("PubKeyHex = %q, want %q", k.PubKeyHex, sampleHex)
+	}
+}

--- a/internal/keycache/types.go
+++ b/internal/keycache/types.go
@@ -1,0 +1,26 @@
+package keycache
+
+import (
+	"context"
+	"errors"
+)
+
+// ErrNotFound is returned when a pubkey lookup finds no matching MeshRadio item.
+var ErrNotFound = errors.New("pubkey not found")
+
+// Key holds a sender node's authoritative decrypt pubkey from the MeshRadio
+// DynamoDB entity. PubKeyHex is the 0x-prefixed X25519 public key as written by
+// run.human's register-radio boundary (base64 → 0x hex), ready for ParseHexKey.
+type Key struct {
+	NodeID    string `dynamodbav:"nodeId"`
+	NodeNum   uint32 `dynamodbav:"nodeNum"`
+	PubKeyHex string `dynamodbav:"publicKey"`
+	Negative  bool   // Not stored in DynamoDB — marks negative cache entries.
+}
+
+// KeyStore defines the interface for fetching a node's pubkey from a backend.
+// Fetch is keyed by the uint32 nodeNum; implementations compose the canonical
+// nodeId ("!%08x") to build the authoritative DynamoDB key.
+type KeyStore interface {
+	Fetch(ctx context.Context, nodeNum uint32) (*Key, error)
+}

--- a/internal/mqtt/crypto.go
+++ b/internal/mqtt/crypto.go
@@ -1,6 +1,7 @@
 package mqtt
 
 import (
+	"context"
 	"crypto/aes"
 	"crypto/cipher"
 	"crypto/rand"
@@ -15,6 +16,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/whereiskurt/meshtk/internal/keycache"
 	meshtastic "github.com/whereiskurt/meshtk/protos/meshtastic/generated"
 	"golang.org/x/crypto/curve25519"
 )
@@ -51,10 +53,13 @@ func (c *MqttClient) decryptPKI(packet *meshtastic.MeshPacket, encryptedData []b
 		return nil, fmt.Errorf("recipient private key has invalid length: %d bytes (expected 32)", len(recipientPrivateKeyBytes))
 	}
 
-	// Fetch sender public key from DEFCON API instead of local nodeDB
-	senderPubKeyHex, err := c.FetchPublicKeyFromDefcon(packet.GetFrom())
+	// Resolve the sender public key from the authoritative keycache (DDB
+	// MeshRadio), NOT the unauthenticated nodes.json feed. On a keycache miss
+	// the configured Fallback decides: nodes.json (bring-up) or NACK (none,
+	// poisoning-resistant). A returned error flows into mqtt.go's nackHandler.
+	senderPubKeyHex, err := c.resolveSenderPubKey(packet.GetFrom())
 	if err != nil {
-		return nil, fmt.Errorf("failed to fetch sender public key from DEFCON API: %v", err)
+		return nil, fmt.Errorf("failed to resolve sender public key: %v", err)
 	}
 
 	senderPublicKeyBytes, err := c.ParseHexKey(senderPubKeyHex)
@@ -90,6 +95,65 @@ func (c *MqttClient) ParseHexKey(hexKey string) ([]byte, error) {
 		return nil, fmt.Errorf("invalid key length: %d, expected 32 (hex string length was %d)", len(keyBytes), len(cleanHex))
 	}
 	return keyBytes, nil
+}
+
+// resolveSenderPubKey returns a node's 0x-hex decrypt pubkey from the
+// authoritative keycache (DDB MeshRadio), applying the configured Fallback on a
+// miss. This is the single decision point shared by BOTH the decrypt site
+// (crypto.go decryptPKI) and the reply-encrypt site (fleet/cmd.go sendPKIReply)
+// — migrating only one would leave stale-key replies (landmine L4).
+//
+//   - keycache hit               → (0x hex, nil)
+//   - miss/degraded, "nodes.json" → FetchPublicKeyFromDefcon (bring-up feed)
+//   - miss/degraded, "none"       → error → existing nackHandler (poisoning closed)
+//
+// Every fallback/miss is logged (never key material) for enrollment-coverage
+// measurement before the deploy-time flip to "none". A nil resolver (e.g. the
+// nodeinfo utility) preserves the legacy feed path.
+//
+// ResolveSenderPubKey is the exported wrapper used by the reply-encrypt site in
+// package fleet; the decrypt site in this package uses the unexported form.
+func (c *MqttClient) ResolveSenderPubKey(nodeNum uint32) (string, error) {
+	return c.resolveSenderPubKey(nodeNum)
+}
+
+func (c *MqttClient) resolveSenderPubKey(nodeNum uint32) (string, error) {
+	if c.keyResolver == nil {
+		// No authoritative resolver wired: legacy feed behavior.
+		return c.fallbackFeedFetch(nodeNum)
+	}
+
+	hexKey, ok, err := c.keyResolver.Resolve(context.Background(), nodeNum)
+	if err == nil && ok {
+		return hexKey, nil
+	}
+
+	// Distinguish a plain miss (ok=false, err=nil) from a store/circuit-breaker
+	// error; both apply the same Fallback branch (degraded ≈ miss, V-degraded).
+	if err != nil {
+		c.log.Warnf("keycache degraded for node !%08x (%v); applying fallback=%q", nodeNum, err, c.keyFallback)
+	}
+
+	switch c.keyFallback {
+	case "none":
+		// Poisoning-resistant: a NODEINFO-injected feed key can NOT change decrypt
+		// behavior. The error flows into the existing nackHandler.
+		c.log.Infof("keycache miss for node !%08x, fallback=none, NACKing (enrollment-coverage)", nodeNum)
+		return "", fmt.Errorf("keycache miss for node !%08x with fallback=none: %w", nodeNum, keycache.ErrNotFound)
+	default: // "nodes.json" (bring-up)
+		c.log.Infof("keycache miss for node !%08x, nodes.json fallback used (enrollment-coverage)", nodeNum)
+		return c.fallbackFeedFetch(nodeNum)
+	}
+}
+
+// fallbackFeedFetch performs the nodes.json feed lookup, routed through an
+// optional test seam (nodesFeedFn) so the fallback branch can be exercised
+// without network I/O.
+func (c *MqttClient) fallbackFeedFetch(nodeNum uint32) (string, error) {
+	if c.nodesFeedFn != nil {
+		return c.nodesFeedFn(nodeNum)
+	}
+	return c.FetchPublicKeyFromDefcon(nodeNum)
 }
 
 // FetchPublicKeyFromDefcon returns the public key for a nodeID, preferring the

--- a/internal/mqtt/crypto_test.go
+++ b/internal/mqtt/crypto_test.go
@@ -1,0 +1,206 @@
+package mqtt
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/whereiskurt/meshtk/internal/keycache"
+)
+
+// Two distinct 32-byte X25519-shaped hex keys. realKey is the authoritative
+// MeshRadio key (DDB); bogusKey stands in for a NODEINFO-injected nodes.json key
+// — the exact hotfix exploit (project_ghost_chatbot_reply_debug): a poisoned feed
+// key must never change decrypt behavior once fallback=none.
+const (
+	realKey  = "0x433d1cec00112233445566778899aabbccddeeff00112233445566778899aabb"
+	bogusKey = "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+)
+
+// fakeKeyStore implements keycache.KeyStore over an in-memory map (no DDB, no
+// network). Absence yields ErrNotFound, exactly like a real MeshRadio GetItem miss.
+type fakeKeyStore struct {
+	keys map[uint32]*keycache.Key
+}
+
+func (f *fakeKeyStore) Fetch(_ context.Context, nodeNum uint32) (*keycache.Key, error) {
+	if k, ok := f.keys[nodeNum]; ok {
+		return k, nil
+	}
+	return nil, keycache.ErrNotFound
+}
+
+// feedSpy records nodes.json fallback calls and returns a fixed key. It proves
+// whether the bogus feed path was consulted at all.
+type feedSpy struct {
+	calls  int
+	retKey string
+}
+
+func (s *feedSpy) fetch(nodeNum uint32) (string, error) {
+	s.calls++
+	return s.retKey, nil
+}
+
+// newTestClient builds an MqttClient wired with a real keycache.KeyResolver over
+// a fake store, a buffered logger (for enrollment-coverage log assertions), and a
+// feed spy standing in for the nodes.json fallback branch. storeKeys are the
+// authoritative DDB keys; feedKey is what the (poisonable) feed would return.
+func newTestClient(t *testing.T, fallback string, storeKeys map[uint32]*keycache.Key, feedKey string) (*MqttClient, *bytes.Buffer, *feedSpy) {
+	t.Helper()
+
+	cache, err := keycache.NewCache(90, 1)
+	if err != nil {
+		t.Fatalf("NewCache() error = %v", err)
+	}
+	t.Cleanup(cache.Close)
+
+	store := &fakeKeyStore{keys: storeKeys}
+	resolver := keycache.NewKeyResolver(cache, store)
+
+	buf := &bytes.Buffer{}
+	logger := log.New()
+	logger.SetOutput(buf)
+	logger.SetLevel(log.InfoLevel)
+
+	spy := &feedSpy{retKey: feedKey}
+
+	c := &MqttClient{
+		log:         logger,
+		keyResolver: resolver,
+		keyFallback: fallback,
+		nodesFeedFn: spy.fetch,
+	}
+	return c, buf, spy
+}
+
+// Case A: an authoritative keycache hit returns the DDB key and the nodes.json
+// feed is never consulted — even under the bring-up fallback=nodes.json.
+func TestResolveSenderPubKey_CacheHit_NodesJsonNeverConsulted(t *testing.T) {
+	const node = uint32(0x433d1cec)
+	keys := map[uint32]*keycache.Key{node: {PubKeyHex: realKey}}
+	c, _, spy := newTestClient(t, "nodes.json", keys, bogusKey)
+
+	got, err := c.resolveSenderPubKey(node)
+	if err != nil {
+		t.Fatalf("resolveSenderPubKey() error = %v", err)
+	}
+	if got != realKey {
+		t.Errorf("resolveSenderPubKey() = %q, want authoritative %q", got, realKey)
+	}
+	if spy.calls != 0 {
+		t.Errorf("nodes.json feed consulted %d times on a keycache hit, want 0", spy.calls)
+	}
+}
+
+// Case B (SECURITY REGRESSION, Success Criterion #3): under fallback=none a bogus
+// key present only in the nodes.json feed must NEVER override or substitute for
+// the authoritative decision.
+//   - B1: keycache HAS the node → returns the real key, feed never consulted.
+//   - B2: keycache is MISSING the node → returns an error (→ NACK), the bogus feed
+//     key is never returned. A NODEINFO injection cannot change decrypt behavior.
+func TestResolveSenderPubKey_Regression_BogusFeedKeyIgnoredUnderFallbackNone(t *testing.T) {
+	const node = uint32(0x433d1cec)
+
+	t.Run("keycache_hit_wins_over_bogus_feed", func(t *testing.T) {
+		keys := map[uint32]*keycache.Key{node: {PubKeyHex: realKey}}
+		c, _, spy := newTestClient(t, "none", keys, bogusKey)
+
+		got, err := c.resolveSenderPubKey(node)
+		if err != nil {
+			t.Fatalf("resolveSenderPubKey() error = %v", err)
+		}
+		if got != realKey {
+			t.Fatalf("resolveSenderPubKey() = %q, want authoritative %q (NOT the bogus feed key)", got, realKey)
+		}
+		if got == bogusKey {
+			t.Fatal("SECURITY: returned the poisoned feed key")
+		}
+		if spy.calls != 0 {
+			t.Errorf("feed consulted %d times under fallback=none, want 0", spy.calls)
+		}
+	})
+
+	t.Run("keycache_miss_nacks_never_uses_bogus_feed", func(t *testing.T) {
+		c, _, spy := newTestClient(t, "none", map[uint32]*keycache.Key{}, bogusKey)
+
+		got, err := c.resolveSenderPubKey(node)
+		if err == nil {
+			t.Fatalf("resolveSenderPubKey() error = nil, want miss error → NACK (got key %q)", got)
+		}
+		if got == bogusKey {
+			t.Fatal("SECURITY: returned the poisoned feed key on a keycache miss under fallback=none")
+		}
+		if got != "" {
+			t.Errorf("resolveSenderPubKey() = %q, want empty on miss", got)
+		}
+		if spy.calls != 0 {
+			t.Errorf("feed consulted %d times under fallback=none, want 0", spy.calls)
+		}
+	})
+}
+
+// Case C: under fallback=nodes.json a keycache miss falls through to the feed and
+// logs the fallback for enrollment-coverage measurement.
+func TestResolveSenderPubKey_FallbackNodesJson_MissFallsThroughAndLogs(t *testing.T) {
+	const node = uint32(0x00abcdef)
+	c, buf, spy := newTestClient(t, "nodes.json", map[uint32]*keycache.Key{}, realKey)
+
+	got, err := c.resolveSenderPubKey(node)
+	if err != nil {
+		t.Fatalf("resolveSenderPubKey() error = %v", err)
+	}
+	if got != realKey {
+		t.Errorf("resolveSenderPubKey() = %q, want feed key %q", got, realKey)
+	}
+	if spy.calls != 1 {
+		t.Errorf("feed consulted %d times, want exactly 1 (fallthrough)", spy.calls)
+	}
+	logs := buf.String()
+	if !strings.Contains(logs, "nodes.json fallback used") || !strings.Contains(logs, "enrollment-coverage") {
+		t.Errorf("missing enrollment-coverage fallback log; got:\n%s", logs)
+	}
+}
+
+// Case D: under fallback=none a keycache miss returns an error (→ existing
+// nackHandler), never consults the feed, and logs the miss.
+func TestResolveSenderPubKey_FallbackNone_MissErrorsAndLogs(t *testing.T) {
+	const node = uint32(0x00abcdef)
+	c, buf, spy := newTestClient(t, "none", map[uint32]*keycache.Key{}, bogusKey)
+
+	got, err := c.resolveSenderPubKey(node)
+	if err == nil {
+		t.Fatalf("resolveSenderPubKey() error = nil, want miss error (got %q)", got)
+	}
+	if spy.calls != 0 {
+		t.Errorf("feed consulted %d times under fallback=none, want 0", spy.calls)
+	}
+	logs := buf.String()
+	if !strings.Contains(logs, "fallback=none") || !strings.Contains(logs, "enrollment-coverage") {
+		t.Errorf("missing enrollment-coverage NACK log; got:\n%s", logs)
+	}
+}
+
+// A nil resolver (e.g. the nodeinfo utility command, or a resolver that failed to
+// build) preserves the legacy nodes.json feed path.
+func TestResolveSenderPubKey_NilResolver_UsesFeed(t *testing.T) {
+	spy := &feedSpy{retKey: realKey}
+	buf := &bytes.Buffer{}
+	logger := log.New()
+	logger.SetOutput(buf)
+
+	c := &MqttClient{log: logger, nodesFeedFn: spy.fetch}
+
+	got, err := c.resolveSenderPubKey(uint32(0x00abcdef))
+	if err != nil {
+		t.Fatalf("resolveSenderPubKey() error = %v", err)
+	}
+	if got != realKey {
+		t.Errorf("resolveSenderPubKey() = %q, want feed key %q", got, realKey)
+	}
+	if spy.calls != 1 {
+		t.Errorf("feed consulted %d times, want 1 (legacy path)", spy.calls)
+	}
+}

--- a/internal/mqtt/mqtt.go
+++ b/internal/mqtt/mqtt.go
@@ -21,6 +21,7 @@ import (
 	mqtt "github.com/eclipse/paho.mqtt.golang"
 
 	log "github.com/sirupsen/logrus"
+	"github.com/whereiskurt/meshtk/internal/keycache"
 	"github.com/whereiskurt/meshtk/pkg/config"
 	meshtastic "github.com/whereiskurt/meshtk/protos/meshtastic/generated"
 )
@@ -38,6 +39,29 @@ type MqttClient struct {
 	pkiPrivateKey  []byte
 	pkiPublicKey   []byte
 	nodes          *NodeDB
+
+	// keyResolver is the shared, process-wide authoritative pubkey source
+	// (internal/keycache, DDB MeshRadio). ONE resolver is threaded into every
+	// fleet client so all ~34 in-process clients share one cache — never
+	// per-client, never per-packet. When nil (e.g. the nodeinfo utility, or a
+	// resolver that failed to build), resolveSenderPubKey preserves the legacy
+	// nodes.json feed behavior.
+	keyResolver *keycache.KeyResolver
+	// keyFallback selects miss behavior: "nodes.json" (bring-up) resolves misses
+	// via the broadcast feed; "none" (poisoning-resistant) returns an error so the
+	// existing nackHandler fires. Plan 66-07; default stays "nodes.json".
+	keyFallback string
+	// nodesFeedFn is a test seam for the nodes.json fallback branch. nil → the
+	// real FetchPublicKeyFromDefcon (feed + pubKeyCache).
+	nodesFeedFn func(nodeNum uint32) (string, error)
+}
+
+// SetKeyResolver wires the shared authoritative pubkey resolver and the miss
+// fallback mode into this client. Called once per fleet client with the ONE
+// process-wide resolver built at fleet startup.
+func (c *MqttClient) SetKeyResolver(r *keycache.KeyResolver, fallback string) {
+	c.keyResolver = r
+	c.keyFallback = fallback
 }
 
 func NewMqttClient(c *config.Config, nodes *NodeDB, handler func(to, from uint32, topic string, portNum meshtastic.PortNum, payload []byte)) *MqttClient {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -59,6 +59,23 @@ type CredCacheConfig struct {
 	NegativeTTLSecs  int `default:"60"`
 }
 
+// KeyCacheConfig sits alongside CredCacheConfig but drives the authoritative
+// Meshtastic pubkey resolver (internal/keycache): a process-wide, cache-first
+// GetItem read of the MeshRadio entity. TTL defaults to 90s (60-120s plain
+// expiry), NOT credcache's 900s — up-to-TTL key staleness is acceptable.
+type KeyCacheConfig struct {
+	TTLSecs          int    `default:"90"`
+	MaxSizeMB        int    `default:"16"`
+	TableName        string `default:"run-human-electro"`
+	TableRegion      string `default:"us-east-1"`
+	DynamoDBEndpoint string `default:""`
+	NegativeTTLSecs  int    `default:"60"`
+	// Fallback selects miss behavior in the decrypt/reply paths (plan 66-07):
+	// "nodes.json" (bring-up) resolves misses via the broadcast feed;
+	// "none" (poisoning-resistant) lets a miss flow into the existing NACK path.
+	Fallback string `default:"nodes.json"`
+}
+
 type Server struct {
 	InspectorListenAddress string `default:"localhost:50051"`
 	ProxyListenAddress     string `default:"0.0.0.0:1883"`
@@ -74,6 +91,7 @@ type Server struct {
 	ShouldLogBlocks        bool   `default:"true"`
 	ShouldLogAllows        bool   `default:"true"`
 	CredCache              CredCacheConfig `json:"CredCache"`
+	KeyCache               KeyCacheConfig  `json:"KeyCache"`
 	ProxyUsername          string          `default:"public"`
 	ProxyPassword          string          `default:"31337"`
 	AdminListenAddress     string          `default:"localhost:9090"`

--- a/pkg/config/meshtk.yaml
+++ b/pkg/config/meshtk.yaml
@@ -85,6 +85,18 @@ Server:
       - "kph"
       - "ax"
       - "meshmap"
+  KeyCache:
+    TTLSecs: 90
+    MaxSizeMB: 16
+    TableName: "run-human-electro"
+    TableRegion: "us-east-1"
+    DynamoDBEndpoint: ""
+    NegativeTTLSecs: 60
+    # Fallback miss behavior for the authoritative pubkey resolver (plan 66-07):
+    #   "nodes.json" (bring-up default) resolves keycache misses via the broadcast feed.
+    #   "none" (poisoning-resistant target) lets a miss flow into the existing NACK path.
+    # Flipping to "none" is a deploy-time op once enrollment coverage is verified.
+    Fallback: "nodes.json"
 
 Fleet:
   - Id: "rebar-fleet"


### PR DESCRIPTION
## Authoritative MeshRadio pubkey keycache — meshtk decrypt firewall (Phase 66, meshtk half)

Replaces meshtk's decrypt-key source from the unauthenticated broadcast `nodes.json` feed with the **authoritative `MeshRadio` DynamoDB record** run.flash captures. Closes the ghost-ricky incident's two failure modes — **staleness** (a re-keyed radio serves a wrong key forever → MAC-verification failures) and **poisoning** (any MQTT publisher can assert any node's pubkey via a NODEINFO injection).

**Approved spec:** `docs/authoritative-pubkey-ddb-design.md` in the defcon.run.34 monorepo · **Companion PR:** defcon.run.34 branch `feat/authoritative-pubkey-ddb` (the `MeshRadio` entity, register-radio write, backfill, and run.flash "Sync keys").

> **Two-repo change. Do NOT deploy meshtk alone.** The monorepo must write + backfill `MeshRadio` **before** flipping `fallback=none`. The default here stays `fallback=nodes.json` (bring-up) so this merge is behavior-neutral until the flip.

### What's in this PR

**`internal/keycache` — one process-wide authoritative pubkey resolver** (MRAD-06)
- Mirrors `internal/credcache` (`CacheAuthenticator`): Otter cache + `singleflight` dedup + **negative caching** + **circuit breaker**, with ONE deliberate divergence — **direct `GetItem`, never `Scan`**.
- Composes the byte-identical ElectroDB key: `pk="$run#nodeid_" + fmt.Sprintf("!%08x", nodeNum)`, `sk="$meshradio_1"`; projects `publicKey` (already `0x` hex) straight to `ParseHexKey`.
- **Overriding constraint:** the resolver is built ONCE (`buildKeyResolver` in `NewFleets`) and shared by every in-process MqttClient, so the whole ~34-client fleet collectively causes ≤ ~one DDB read per node per TTL — never per-packet, never per-client. Plain 60–120s TTL expiry (default 90s), not write-invalidation.

**Decrypt swap at BOTH pubkey call sites** (MRAD-07 — missing either leaves stale-key replies)
- `internal/mqtt/crypto.go` `decryptPKI` (decrypt) and `internal/app/fleet/cmd.go` `sendPKIReply` (reply-encrypt) both resolve via the shared keycache through one `resolveSenderPubKey` decision point.
- **Fallback flag** `Server.KeyCache.Fallback`: `nodes.json` (bring-up, default) resolves misses via the legacy feed; `none` (poisoning-resistant) lets a miss flow into the **existing** `nackHandler` (no new NACK plumbing). Every fallback/miss is logged for enrollment-coverage — never key material.
- `KeyCacheConfig` added to `pkg/config` parallel to `CredCacheConfig` (table/region already match: `run-human-electro` / `us-east-1`).

### Verification (real runs)
- `go build ./...`, `go vet ./internal/mqtt/... ./internal/app/... ./internal/keycache/...` → clean.
- `go test ./internal/keycache/... ./internal/mqtt/...` → **ok**. keycache table-tests ported from credcache (hit / miss / negative-cache / singleflight-collapse / circuit-breaker) + a Go **key-parity** test locking `$run#nodeid_!433d1cec` / `$meshradio_1`.
- **Security regression** (`internal/mqtt/crypto_test.go`): under `fallback=none`, a bogus NODEINFO-injected feed key never overrides the DDB key nor substitutes on a miss — proving a broker injection cannot change decrypt behavior (Success Criterion #3, the exact hotfix exploit).

### Not done (deploy-time)
The `fallback=none` flip is an operator/deploy step, intentionally not made here.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
