### PR TITLE
feat: secret-seeded deterministic node keypairs

### DIFF
--- a/internal/app/cmdargs.go
+++ b/internal/app/cmdargs.go
@@ -46,6 +46,7 @@ func (a *App) RegisterOsArgs() {
 	cmd.GlobalS("HomeFolder", &a.Config.HomeFolder, []string{"d", "home"}, nil)
 	cmd.GlobalS("VerboseLevel", &a.Config.VerboseLevel, []string{"v", "verbose"}, nil)
 	cmd.GlobalS("ConfigFileName", &a.Config.ConfigFileName, []string{"c", "config"}, nil)
+	cmd.GlobalS("GhostKeySecret", &a.Config.GhostKeySecret, nil, []string{"MESHTK_GHOST_KEY_SECRET"})
 
 	ni := nodeinfo.NewNodeInfo(a.Config)
 	nodeInfoCmd := cmd.NewCmd([]string{"nodeinfo", "n"}, ni.Help)

--- a/internal/app/fleet/cmd.go
+++ b/internal/app/fleet/cmd.go
@@ -86,6 +86,7 @@ func (f *FleetCmd) Simulate(cmd *cobra.Command, argz []string) {
 
 	for idx := range f.Config.Fleet {
 		f.initNodeDb(idx)
+		f.overrideFleetKeys(idx)
 		mqttClient := internal.NewMqttClient(f.Config, &f.Nodes[idx], f.FleetNodeHandler)
 		
 		// Set up ACK handler for this fleet member

--- a/internal/app/fleet/keyoverride_test.go
+++ b/internal/app/fleet/keyoverride_test.go
@@ -1,0 +1,38 @@
+package fleet
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/whereiskurt/meshtk/internal/mqtt"
+	"github.com/whereiskurt/meshtk/pkg/config"
+)
+
+func TestOverrideFleetKeysGated(t *testing.T) {
+	node := mqtt.NewNode("msh/US/2/e/dc.run")
+	node.From = 2076591764
+	node.PubKey = "0xcommittedpub"
+	node.PrivKey = "0xcommittedpriv"
+
+	f := &FleetCmd{}
+	f.Config = &config.Config{}
+	f.Nodes = []mqtt.NodeDB{{node.From: node}}
+	f.NodesMutex = make([]sync.Mutex, 1)
+
+	// Secret absent: committed keys retained.
+	f.overrideFleetKeys(0)
+	if node.PrivKey != "0xcommittedpriv" {
+		t.Fatalf("expected committed key retained, got %s", node.PrivKey)
+	}
+
+	// Secret present: keys overridden with derived values.
+	f.Config.GhostKeySecret = "top-secret"
+	f.overrideFleetKeys(0)
+	_, wantPriv, _ := mqtt.DeriveNodeKey("top-secret", 2076591764)
+	if node.PrivKey == "0xcommittedpriv" {
+		t.Fatal("expected key to be overridden when secret is set")
+	}
+	if node.PrivKey != mqtt.HexKey(wantPriv) {
+		t.Fatalf("privkey = %s, want %s", node.PrivKey, mqtt.HexKey(wantPriv))
+	}
+}

--- a/internal/app/fleet/nodes.go
+++ b/internal/app/fleet/nodes.go
@@ -16,6 +16,23 @@ import (
 
 var curve = ecdh.X25519()
 
+// overrideFleetKeys replaces every node's committed keypair in fleet idx with a
+// deterministic secret-derived one, but only when MESHTK_GHOST_KEY_SECRET is
+// set. Absent the secret it is a no-op and committed keys are used as-is.
+func (f *FleetCmd) overrideFleetKeys(idx int) {
+	secret := f.Config.GhostKeySecret
+	if secret == "" {
+		return
+	}
+	f.NodesMutex[idx].Lock()
+	defer f.NodesMutex[idx].Unlock()
+	for _, node := range f.Nodes[idx] {
+		if err := node.ApplyDerivedKey(secret); err != nil {
+			f.Config.Log.Warnf("ghost key override failed for node %d: %v", node.From, err)
+		}
+	}
+}
+
 func (f *FleetCmd) makeNode(num int, totalNodes int, fleet config.Fleet, idx int) (n *mqtt.Node) {
 	n = mqtt.NewNode(f.Config.NodeInfo.Topic)
 
@@ -56,6 +73,13 @@ func (f *FleetCmd) makeNode(num int, totalNodes int, fleet config.Fleet, idx int
 	role := roles[propRand.Intn(len(roles))]
 
 	n.UpdateUser(nodeID, longName, shortName, hwModel, role, publicKeyBytes, privateKeyBytes)
+
+	// When a server-only secret is present, override the seed-derived keypair
+	// with one deterministically derived from that secret (covers the generate
+	// path; loaded nodes are covered by overrideFleetKeys after initNodeDb).
+	if f.Config.GhostKeySecret != "" {
+		_ = n.ApplyDerivedKey(f.Config.GhostKeySecret)
+	}
 
 	baseLatitude := int32(0)
 	baseLongitude := int32(0)

--- a/internal/mqtt/keyderive.go
+++ b/internal/mqtt/keyderive.go
@@ -1,0 +1,31 @@
+package mqtt
+
+import (
+	"crypto/ecdh"
+	"crypto/hkdf"
+	"crypto/sha256"
+	"fmt"
+)
+
+// DeriveNodeKey deterministically derives a valid X25519 keypair from a
+// server-only secret and the node's stable ID. The public key is computed from
+// the private scalar, so the pair always matches. Same (secret, nodeID) yields
+// the same keypair on every call — keys survive restarts unchanged.
+func DeriveNodeKey(secret string, nodeID uint32) (pub []byte, priv []byte, err error) {
+	info := fmt.Sprintf("meshtk-node-key:%08x", nodeID)
+	seed, err := hkdf.Key(sha256.New, []byte(secret), nil, info, 32)
+	if err != nil {
+		return nil, nil, fmt.Errorf("hkdf: %w", err)
+	}
+
+	privKey, err := ecdh.X25519().NewPrivateKey(seed)
+	if err != nil {
+		return nil, nil, fmt.Errorf("x25519 private key: %w", err)
+	}
+	return privKey.PublicKey().Bytes(), privKey.Bytes(), nil
+}
+
+// HexKey formats raw key bytes as meshtk's on-wire "0x"-prefixed lowercase hex.
+func HexKey(b []byte) string {
+	return fmt.Sprintf("0x%x", b)
+}

--- a/internal/mqtt/keyderive_test.go
+++ b/internal/mqtt/keyderive_test.go
@@ -1,0 +1,78 @@
+package mqtt
+
+import (
+	"bytes"
+	"encoding/hex"
+	"testing"
+
+	"golang.org/x/crypto/curve25519"
+)
+
+func TestDeriveNodeKeyDeterministic(t *testing.T) {
+	pub1, priv1, err := DeriveNodeKey("top-secret", 2076591764)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	pub2, priv2, err := DeriveNodeKey("top-secret", 2076591764)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !bytes.Equal(priv1, priv2) || !bytes.Equal(pub1, pub2) {
+		t.Fatal("derivation not deterministic for identical inputs")
+	}
+	if len(priv1) != 32 || len(pub1) != 32 {
+		t.Fatalf("expected 32-byte keys, got priv=%d pub=%d", len(priv1), len(pub1))
+	}
+}
+
+func TestDeriveNodeKeyVariesByInput(t *testing.T) {
+	_, privA, _ := DeriveNodeKey("top-secret", 1)
+	_, privB, _ := DeriveNodeKey("top-secret", 2)
+	_, privC, _ := DeriveNodeKey("other-secret", 1)
+	if bytes.Equal(privA, privB) {
+		t.Fatal("different nodeIDs produced identical private keys")
+	}
+	if bytes.Equal(privA, privC) {
+		t.Fatal("different secrets produced identical private keys")
+	}
+}
+
+func TestDeriveNodeKeyRoundTrip(t *testing.T) {
+	// Two derived nodes must be able to compute a shared X25519 secret,
+	// proving pub is the true match for priv (production uses curve25519.X25519).
+	pubA, privA, _ := DeriveNodeKey("top-secret", 100)
+	pubB, privB, _ := DeriveNodeKey("top-secret", 200)
+
+	sharedAB, err := curve25519.X25519(privA, pubB)
+	if err != nil {
+		t.Fatalf("X25519 A->B failed: %v", err)
+	}
+	sharedBA, err := curve25519.X25519(privB, pubA)
+	if err != nil {
+		t.Fatalf("X25519 B->A failed: %v", err)
+	}
+	if !bytes.Equal(sharedAB, sharedBA) {
+		t.Fatal("shared secrets differ — derived pub does not match priv")
+	}
+}
+
+func TestApplyDerivedKeyOverwrites(t *testing.T) {
+	node := NewNode("msh/US/2/e/dc.run")
+	node.From = 2076591764
+	node.PubKey = "0xaaaa"
+	node.PrivKey = "0xbbbb"
+
+	if err := node.ApplyDerivedKey("top-secret"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	pub, priv, _ := DeriveNodeKey("top-secret", 2076591764)
+	wantPub := "0x" + hex.EncodeToString(pub)
+	wantPriv := "0x" + hex.EncodeToString(priv)
+	if node.PubKey != wantPub {
+		t.Fatalf("pubkey = %s, want %s", node.PubKey, wantPub)
+	}
+	if node.PrivKey != wantPriv {
+		t.Fatalf("privkey = %s, want %s", node.PrivKey, wantPriv)
+	}
+}

--- a/internal/mqtt/node.go
+++ b/internal/mqtt/node.go
@@ -257,6 +257,19 @@ func (node *Node) UpdateUser(from uint32, longName, shortName, hwModel, role str
 	}
 }
 
+// ApplyDerivedKey overwrites the node's keypair with one deterministically
+// derived from secret and the node's stable ID. Used to override committed
+// decoy keys with production keys when MESHTK_GHOST_KEY_SECRET is set.
+func (node *Node) ApplyDerivedKey(secret string) error {
+	pub, priv, err := DeriveNodeKey(secret, node.From)
+	if err != nil {
+		return err
+	}
+	node.PubKey = HexKey(pub)
+	node.PrivKey = HexKey(priv)
+	return nil
+}
+
 type NodeDB map[uint32]*Node
 
 func (db NodeDB) Prune(seenByTtl, neighborTtl, metricsTtl, mapReportTtl int64) {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -29,6 +29,7 @@ type Config struct {
 	Log            *log.Logger `json:"-"`
 	LogFolder      string
 	ConfigFileName string `json:"-"`
+	GhostKeySecret string `json:"-"`
 
 	Release struct {
 		Date    string


### PR DESCRIPTION
## What

Derives production ghost/rabbit X25519 keypairs from a server-only secret
(`MESHTK_GHOST_KEY_SECRET`) instead of the keys committed in `nodes.*.json`, so
the committed keys become inert decoys.

- `DeriveNodeKey(secret, nodeID)` — HKDF-SHA256(secret, info=nodeID) → 32-byte
  X25519 private scalar; public key derived from it, so the pair always matches.
- `Node.ApplyDerivedKey(secret)` overwrites a node's committed keypair.
- Fleet override pass runs when the secret is set: `overrideFleetKeys` after
  `initNodeDb` (loaded ghosts/rabbits) + `ApplyDerivedKey` in `makeNode`
  (freshly generated nodes).

## Why

Committed private keys let anyone reading the repo impersonate a ghost or
decrypt its DMs, and edits to those files change prod behavior. XOR-masking is
unsound (breaks the X25519 pub↔priv relationship). Deterministic derivation from
a secret gives valid, restart-stable keypairs while making repo keys decoys.

## Behavior

- **Secret present (prod):** committed keys ignored; keys derived from the
  secret. Deterministic → survive restarts unchanged.
- **Secret absent (localdev/tests):** committed keys retained, so ghosts still
  decrypt against each other locally.

Pairs with the defcon.run.34 PR that provisions the SSM param and injects it
into the `run-mqtt-ghosts` container. First deploy rotates every node's pubkey
once (fine: nobody connected, everyone reflashes for a fresh node DB).

## Tests

- `DeriveNodeKey`: determinism, varies by secret & nodeID, X25519 round-trip
  (derived pub is the true match for priv).
- `ApplyDerivedKey` overwrites committed keys.
- `overrideFleetKeys` gating: no-op without secret, overrides with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)