### PR TITLE
fix(fleet): guard nil c.Log in buildKeyResolver (startup SIGSEGV crash-loop)

### DIFF
--- a/internal/app/fleet/cmd.go
+++ b/internal/app/fleet/cmd.go
@@ -88,23 +88,34 @@ func NewFleets(c *config.Config) (f *FleetCmd) {
 func buildKeyResolver(c *config.Config) *keycache.KeyResolver {
 	kc := c.Server.KeyCache
 
+	// NOTE: buildKeyResolver runs inside NewFleets during early bootstrap
+	// (NewApp -> RegisterOsArgs -> NewFleets), BEFORE c.Log is wired, so c.Log
+	// is nil here. Guard every logger call — an unconditional c.Log.*f panics
+	// the whole meshtk process at startup (SIGSEGV in logrus). Runtime resolve/
+	// fallback logging (crypto.go) is unaffected: c.Log is set by decrypt time.
 	cache, err := keycache.NewCache(kc.TTLSecs, kc.MaxSizeMB)
 	if err != nil {
-		c.Log.Errorf("keycache: failed to create pubkey cache (%v); falling back to nodes.json", err)
+		if c.Log != nil {
+			c.Log.Errorf("keycache: failed to create pubkey cache (%v); falling back to nodes.json", err)
+		}
 		return nil
 	}
 
 	store, err := keycache.NewDynamoDBStore(kc.TableName, kc.TableRegion, kc.DynamoDBEndpoint)
 	if err != nil {
-		c.Log.Errorf("keycache: failed to create DynamoDB store (%v); falling back to nodes.json", err)
+		if c.Log != nil {
+			c.Log.Errorf("keycache: failed to create DynamoDB store (%v); falling back to nodes.json", err)
+		}
 		return nil
 	}
 
 	resolver := keycache.NewKeyResolver(cache, store,
 		keycache.WithNegativeTTL(time.Duration(kc.NegativeTTLSecs)*time.Second),
 	)
-	c.Log.Infof("keycache: authoritative pubkey resolver ready (table=%s region=%s ttl=%ds fallback=%q)",
-		kc.TableName, kc.TableRegion, kc.TTLSecs, kc.Fallback)
+	if c.Log != nil {
+		c.Log.Infof("keycache: authoritative pubkey resolver ready (table=%s region=%s ttl=%ds fallback=%q)",
+			kc.TableName, kc.TableRegion, kc.TTLSecs, kc.Fallback)
+	}
 	return resolver
 }
 func (f *FleetCmd) Help(cmd *cobra.Command, argz []string) {

--- a/internal/app/fleet/keyresolver_test.go
+++ b/internal/app/fleet/keyresolver_test.go
@@ -1,0 +1,34 @@
+package fleet
+
+import (
+	"testing"
+
+	"github.com/whereiskurt/meshtk/pkg/config"
+)
+
+// TestBuildKeyResolver_NilLoggerDoesNotPanic is a regression guard for the
+// startup SIGSEGV that crash-looped run.mqtt at deploy time: buildKeyResolver
+// runs inside NewFleets during early bootstrap (NewApp -> RegisterOsArgs ->
+// NewFleets), BEFORE c.Log is wired, so c.Log is nil. An unconditional
+// c.Log.Infof / c.Log.Errorf there nil-derefs logrus and panics the whole
+// process. This exercises the full construction path (including the final
+// "resolver ready" Infof at the original crash site) with c.Log == nil.
+func TestBuildKeyResolver_NilLoggerDoesNotPanic(t *testing.T) {
+	c := &config.Config{}
+	// Valid keycache config so NewCache/NewDynamoDBStore succeed and execution
+	// reaches the final Infof (the exact line that crashed in prod).
+	c.Server.KeyCache = config.KeyCacheConfig{
+		TTLSecs:         90,
+		MaxSizeMB:       16,
+		TableName:       "run-human-electro",
+		TableRegion:     "us-east-1",
+		NegativeTTLSecs: 60,
+		Fallback:        "nodes.json",
+	}
+	// c.Log intentionally left nil — mirrors the NewFleets bootstrap ordering.
+
+	resolver := buildKeyResolver(c) // must NOT panic on the nil logger
+	if resolver == nil {
+		t.Fatal("expected a resolver from valid config with a nil logger, got nil")
+	}
+}


### PR DESCRIPTION
Hotfix for the run.mqtt crash-loop on the Phase 66 keycache deploy (PR #5). `buildKeyResolver` runs in `NewFleets` during early bootstrap before `c.Log` is wired, so the unconditional `c.Log.Infof`/`Errorf` nil-dereferenced logrus and SIGSEGV-panicked meshtk at startup (meshtk + ghosts exit 2). Unit tests passed because the harness sets a logger. Guards every `c.Log` call in `buildKeyResolver` + adds a nil-logger regression test. Verified: `go build`/`vet`/`test` green, and the real binary boots clean (exit 0, no SIGSEGV). Runtime resolve/fallback logging unaffected (c.Log set by decrypt time).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>