### PR TITLE
fix(fleet): publish chatbot PKI reply on ghost's own gateway topic

### DIFF
--- a/internal/app/fleet/cmd.go
+++ b/internal/app/fleet/cmd.go
@@ -261,6 +261,15 @@ func waitForAllCompletions(completionChan chan int, count int) chan struct{} {
 	return done
 }
 
+// ownGatewayTopic builds the MQTT topic a fleet node publishes its OWN packets
+// on: "<channelBase>/!<nodeNum hex>". Every meshtk publisher (ACK, NodeInfo,
+// position, and now the chatbot reply) must use the replying node's own gateway
+// id here — NOT the incoming sender's topic — or the receiving device silently
+// drops the packet as a self-echo (it sees its own gateway id in the topic).
+func ownGatewayTopic(channelBase string, nodeNum uint32) string {
+	return fmt.Sprintf("%s/!%08x", channelBase, nodeNum)
+}
+
 func (n *FleetCmd) sendPKIReply(toFleetIdx int, to, from uint32, topic string, reply string) {
 	// Get the nodes to access their keys
 	_, toNode, _, _ := n.FindNodes(to, from)
@@ -300,12 +309,21 @@ func (n *FleetCmd) sendPKIReply(toFleetIdx int, to, from uint32, topic string, r
 		return
 	}
 
+	// Publish the reply on THIS ghost's OWN gateway topic, mirroring
+	// publishACK/publishNodeInfo (behaviours.go). Reusing the incoming `topic`
+	// puts the reply on the *sender's* gateway topic (e.g. msh/US/2/e/PKI/!<sender>),
+	// which the sending device ignores as a self-echo — so chatbot replies never
+	// arrived at the device even though they were published, ACKed, and correctly
+	// PKI-encrypted. `to` is the replying ghost's node num. (Phase 66 field bug,
+	// confirmed on-wire: republishing a real reply to !<ghost> made it appear.)
+	replyTopic := ownGatewayTopic(n.Config.NodeInfo.Topic, to)
+
 	// Send the PKI encrypted reply
 	// Note: from and to are swapped for the reply
 	err = n.MqttClient[toFleetIdx].PublishPKIMessage(
 		to,   // sender of reply (was receiver of original message)
 		from, // receiver of reply (was sender of original message)
-		topic,
+		replyTopic,
 		meshtastic.PortNum_TEXT_MESSAGE_APP,
 		[]byte(reply),
 		senderPrivKeyBytes,

--- a/internal/app/fleet/reply_topic_test.go
+++ b/internal/app/fleet/reply_topic_test.go
@@ -1,0 +1,33 @@
+package fleet
+
+import "testing"
+
+// TestOwnGatewayTopic locks the Phase-66 chatbot-reply fix: a ghost must publish
+// its PKI reply on ITS OWN gateway topic, never on the sender's incoming topic.
+//
+// Field bug: sendPKIReply reused the incoming `topic`
+// (msh/US/2/e/PKI/!<sender>). The sender is its own MQTT gateway, and a
+// Meshtastic device ignores traffic on its own gateway topic (self-echo), so
+// replies were published + ACKed + PKI-encrypted correctly yet never displayed.
+// Republishing a captured reply to !<ghost> made it appear instantly on-device.
+func TestOwnGatewayTopic(t *testing.T) {
+	const base = "msh/US/2/e/dc.run"
+	const ghost = uint32(0x1555f041) // goldstein
+	const sender = uint32(0x435990e4) // the user's device (was the incoming gateway)
+
+	got := ownGatewayTopic(base, ghost)
+
+	if want := "msh/US/2/e/dc.run/!1555f041"; got != want {
+		t.Fatalf("reply topic = %q, want %q", got, want)
+	}
+
+	// Regression guard: the reply must NOT go to the sender's gateway topic.
+	if senderTopic := ownGatewayTopic(base, sender); got == senderTopic {
+		t.Fatalf("reply topic reused the sender's gateway topic %q — device would self-drop it", senderTopic)
+	}
+
+	// pad-8 lowercase hex, matching publishACK/publishNodeInfo formatting.
+	if small := ownGatewayTopic(base, 0xabc); small != "msh/US/2/e/dc.run/!00000abc" {
+		t.Fatalf("node id not pad-8 lowercase hex: %q", small)
+	}
+}


### PR DESCRIPTION
Fixes chatbot ghosts' PKI replies never reaching the sender's device.

**Root cause:** `sendPKIReply` reused the incoming `topic` (`msh/US/2/e/PKI/!<sender>`) — the *sender's* own gateway topic. Meshtastic devices ignore traffic on their own gateway topic (self-echo), so replies were published + ACKed + correctly PKI-encrypted yet silently dropped on-device. NodeInfo (channel topic) still arrived, masking it as intermittent 'no reply'.

**Fix:** publish on the *replying ghost's* own gateway topic via new `ownGatewayTopic()` helper, matching `publishACK`/`publishNodeInfo`/`publishPosition`. Confirmed on-wire: republishing a captured reply to `!<ghost>` made it appear on-device instantly. Adds `TestOwnGatewayTopic`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)