### PR TITLE
fix(fleet): PKI reply on the PKI base of the ghost's own gateway topic

### DIFF
--- a/internal/app/fleet/cmd.go
+++ b/internal/app/fleet/cmd.go
@@ -261,13 +261,25 @@ func waitForAllCompletions(completionChan chan int, count int) chan struct{} {
 	return done
 }
 
-// ownGatewayTopic builds the MQTT topic a fleet node publishes its OWN packets
-// on: "<channelBase>/!<nodeNum hex>". Every meshtk publisher (ACK, NodeInfo,
-// position, and now the chatbot reply) must use the replying node's own gateway
-// id here — NOT the incoming sender's topic — or the receiving device silently
-// drops the packet as a self-echo (it sees its own gateway id in the topic).
-func ownGatewayTopic(channelBase string, nodeNum uint32) string {
-	return fmt.Sprintf("%s/!%08x", channelBase, nodeNum)
+// replyTopicFor builds the topic a chatbot ghost publishes its PKI reply on:
+// the SAME channel base as the incoming DM (always ".../2/e/PKI"), but with the
+// replying ghost's OWN gateway id, "<base>/!<ghostNum hex>".
+//
+// Two constraints, both learned the hard way on-wire:
+//   1. Own gateway, not the sender's: reusing the incoming topic
+//      (".../PKI/!<sender>") publishes on the SENDER's gateway topic, which the
+//      sending device ignores as a self-echo — replies never displayed.
+//   2. PKI base, not the channel base: a PKI-encrypted reply republished on the
+//      channel topic (".../dc.run/!<ghost>") is dropped by the device, which
+//      tries CHANNEL decryption on it. The DM must stay on the PKI base so the
+//      device routes it to PKI decryption. Deriving the base from the incoming
+//      DM topic (the fleet only subscribes to ".../2/e/PKI/#") keeps it there.
+func replyTopicFor(incomingTopic string, ghostNum uint32) string {
+	base := incomingTopic
+	if i := strings.LastIndex(incomingTopic, "/"); i >= 0 {
+		base = incomingTopic[:i]
+	}
+	return fmt.Sprintf("%s/!%08x", base, ghostNum)
 }
 
 func (n *FleetCmd) sendPKIReply(toFleetIdx int, to, from uint32, topic string, reply string) {
@@ -316,7 +328,7 @@ func (n *FleetCmd) sendPKIReply(toFleetIdx int, to, from uint32, topic string, r
 	// arrived at the device even though they were published, ACKed, and correctly
 	// PKI-encrypted. `to` is the replying ghost's node num. (Phase 66 field bug,
 	// confirmed on-wire: republishing a real reply to !<ghost> made it appear.)
-	replyTopic := ownGatewayTopic(n.Config.NodeInfo.Topic, to)
+	replyTopic := replyTopicFor(topic, to)
 
 	// Send the PKI encrypted reply
 	// Note: from and to are swapped for the reply

--- a/internal/app/fleet/reply_topic_test.go
+++ b/internal/app/fleet/reply_topic_test.go
@@ -2,32 +2,34 @@ package fleet
 
 import "testing"
 
-// TestOwnGatewayTopic locks the Phase-66 chatbot-reply fix: a ghost must publish
-// its PKI reply on ITS OWN gateway topic, never on the sender's incoming topic.
-//
-// Field bug: sendPKIReply reused the incoming `topic`
-// (msh/US/2/e/PKI/!<sender>). The sender is its own MQTT gateway, and a
-// Meshtastic device ignores traffic on its own gateway topic (self-echo), so
-// replies were published + ACKed + PKI-encrypted correctly yet never displayed.
-// Republishing a captured reply to !<ghost> made it appear instantly on-device.
-func TestOwnGatewayTopic(t *testing.T) {
-	const base = "msh/US/2/e/dc.run"
-	const ghost = uint32(0x1555f041) // goldstein
-	const sender = uint32(0x435990e4) // the user's device (was the incoming gateway)
+// TestReplyTopicFor locks the Phase-66 chatbot-reply fix. A ghost's PKI reply
+// must go to: (1) its OWN gateway id, not the sender's (else the sending device
+// self-drops it), and (2) the PKI base, not the channel base (else the device
+// tries channel-decryption on a PKI packet and drops it). Both were confirmed
+// on-wire: replies on ".../PKI/!<sender>" and ".../dc.run/!<ghost>" never
+// displayed; ".../PKI/!<ghost>" did.
+func TestReplyTopicFor(t *testing.T) {
+	const incoming = "msh/US/2/e/PKI/!435990e4" // DM arrived from the user's device
+	const ghost = uint32(0x1555f041)            // goldstein
 
-	got := ownGatewayTopic(base, ghost)
+	got := replyTopicFor(incoming, ghost)
 
-	if want := "msh/US/2/e/dc.run/!1555f041"; got != want {
+	if want := "msh/US/2/e/PKI/!1555f041"; got != want {
 		t.Fatalf("reply topic = %q, want %q", got, want)
 	}
 
-	// Regression guard: the reply must NOT go to the sender's gateway topic.
-	if senderTopic := ownGatewayTopic(base, sender); got == senderTopic {
-		t.Fatalf("reply topic reused the sender's gateway topic %q — device would self-drop it", senderTopic)
+	// Must keep the PKI base from the incoming DM, never the channel base.
+	if got == "msh/US/2/e/dc.run/!1555f041" {
+		t.Fatalf("reply must stay on the PKI base, not the channel base: %q", got)
 	}
 
-	// pad-8 lowercase hex, matching publishACK/publishNodeInfo formatting.
-	if small := ownGatewayTopic(base, 0xabc); small != "msh/US/2/e/dc.run/!00000abc" {
-		t.Fatalf("node id not pad-8 lowercase hex: %q", small)
+	// Must NOT reuse the sender's gateway topic (self-echo drop).
+	if got == incoming {
+		t.Fatalf("reply reused the sender's gateway topic %q — device self-drops it", incoming)
+	}
+
+	// Region-less base is preserved too (fleet subscribes msh/2/e/PKI/# as well).
+	if r := replyTopicFor("msh/2/e/PKI/!435990e4", 0xabc); r != "msh/2/e/PKI/!00000abc" {
+		t.Fatalf("region-less base or pad-8 hex wrong: %q", r)
 	}
 }


### PR DESCRIPTION
Follow-up to #8. Publishing the reply on the channel base (`.../dc.run/!<ghost>`) is wrong — a PKI-encrypted packet on the channel topic is dropped by the device (it tries channel decryption). Confirmed on-wire on v0.0.35. Derive the reply topic from the incoming DM topic (always the PKI base, `.../2/e/PKI/#`) and swap in the ghost's own gateway id — keeping both invariants (PKI base + own gateway). Updates TestReplyTopicFor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)