### PR TITLE
feat(otp): server-secret derived TOTP seeds (committed OtpUrl secrets become decoys)

### DIFF
--- a/internal/app/fleet/cmd.go
+++ b/internal/app/fleet/cmd.go
@@ -84,6 +84,20 @@ func NewFleets(c *config.Config) (f *FleetCmd) {
 		f.RecentReqMux = append(f.RecentReqMux, sync.Mutex{})
 
 		otpURL := f.Config.Fleet[i].OtpUrl
+		if otpURL != "" && c.GhostKeySecret != "" {
+			// Same server-secret munging as the node keypairs (ApplyDerivedKey):
+			// the committed OtpUrl secret is a decoy HKDF input; the handler
+			// validates against the derived secret. A derivation failure is
+			// fail-CLOSED (nil handler, OTP never unlocks) — never a silent
+			// fallback to the committed plaintext.
+			derived, err := otp.DeriveOtpUrl(c.GhostKeySecret, f.Config.Fleet[i].Id, otpURL)
+			if err != nil {
+				c.Log.Errorf("⚠️ OTP secret derivation failed for %s (OTP disabled): %v", f.Config.Fleet[i].Id, err)
+				otpURL = ""
+			} else {
+				otpURL = derived
+			}
+		}
 		if otpURL != "" {
 			otpHandler, _ := otp.NewOTPHandler(otpURL)
 			f.OTPHandler = append(f.OTPHandler, otpHandler)

--- a/pkg/otp/derive.go
+++ b/pkg/otp/derive.go
@@ -1,0 +1,49 @@
+package otp
+
+import (
+	"crypto/hkdf"
+	"crypto/sha256"
+	"encoding/base32"
+	"fmt"
+	"net/url"
+)
+
+// DeriveTotpSecret deterministically derives the REAL base32 TOTP secret for a
+// fleet entry from a server-only secret, the entry's stable Id, and the secret
+// committed in the config's OtpUrl. The committed value is only an HKDF input —
+// a decoy that never validates anything once derivation is active — so rotating
+// it in the YAML rotates the effective seed without touching the server secret.
+// Same (serverSecret, fleetID, committedSecret) yields the same secret on every
+// call. This is the OTP twin of internal/mqtt's DeriveNodeKey: HKDF-SHA256,
+// nil salt, a domain-separated info label, here with 20 output bytes encoded as
+// unpadded uppercase RFC 4648 base32 (a standard authenticator-app secret).
+func DeriveTotpSecret(serverSecret, fleetID, committedSecret string) (string, error) {
+	info := fmt.Sprintf("meshtk-otp-seed:%s:%s", fleetID, committedSecret)
+	key, err := hkdf.Key(sha256.New, []byte(serverSecret), nil, info, 20)
+	if err != nil {
+		return "", fmt.Errorf("hkdf: %w", err)
+	}
+	return base32.StdEncoding.WithPadding(base32.NoPadding).EncodeToString(key), nil
+}
+
+// DeriveOtpUrl returns otpURL with ONLY its secret query param replaced by the
+// derived secret. Every other param (algorithm, digits, period, issuer) and the
+// label pass through, so authenticator enrollments keep their display identity.
+func DeriveOtpUrl(serverSecret, fleetID, otpURL string) (string, error) {
+	u, err := url.Parse(otpURL)
+	if err != nil {
+		return "", fmt.Errorf("parse otp url: %w", err)
+	}
+	q := u.Query()
+	committed := q.Get("secret")
+	if committed == "" {
+		return "", fmt.Errorf("otp url has no secret param")
+	}
+	derived, err := DeriveTotpSecret(serverSecret, fleetID, committed)
+	if err != nil {
+		return "", err
+	}
+	q.Set("secret", derived)
+	u.RawQuery = q.Encode()
+	return u.String(), nil
+}

--- a/pkg/otp/derive_test.go
+++ b/pkg/otp/derive_test.go
@@ -1,0 +1,77 @@
+package otp
+
+import (
+	"net/url"
+	"strings"
+	"testing"
+)
+
+// Shared cross-implementation vectors: the SAME table lives in run.human's
+// mesh-otp-derive vitest (defcon.run.34 apps/run.human/webapp/src/lib/
+// __tests__/mesh-otp-derive.test.ts). If either side changes, both fail.
+var deriveVectors = []struct {
+	serverSecret string
+	fleetID      string
+	committed    string
+	derived      string
+}{
+	{"test-server-secret", "ghost.goldstein", "GZRGQNKGKN4DINQ", "XHNN23O25QAZITZ4CZTCXU4NIR6LRRCK"},
+	{"test-server-secret", "ghost.mudge", "NA2DG", "7KS3JJBI5CD6POHUUCC6XWHE65TXHGGX"},
+	{"another-secret", "ghost.condor", "EZRWO", "74M2OE6WWHRXQYZUBYC6ZJ6TX5NKGRDR"},
+}
+
+func TestDeriveTotpSecretVectors(t *testing.T) {
+	for _, v := range deriveVectors {
+		got, err := DeriveTotpSecret(v.serverSecret, v.fleetID, v.committed)
+		if err != nil {
+			t.Fatalf("DeriveTotpSecret(%s): %v", v.fleetID, err)
+		}
+		if got != v.derived {
+			t.Errorf("DeriveTotpSecret(%s) = %s, want %s", v.fleetID, got, v.derived)
+		}
+	}
+}
+
+func TestDeriveTotpSecretDomainSeparation(t *testing.T) {
+	a, _ := DeriveTotpSecret("s", "ghost.a", "SEED")
+	b, _ := DeriveTotpSecret("s", "ghost.b", "SEED")
+	c, _ := DeriveTotpSecret("s2", "ghost.a", "SEED")
+	d, _ := DeriveTotpSecret("s", "ghost.a", "SEED2")
+	if a == b || a == c || a == d {
+		t.Errorf("expected distinct secrets across id/server/committed changes: %s %s %s %s", a, b, c, d)
+	}
+}
+
+func TestDeriveOtpUrlSwapsOnlySecret(t *testing.T) {
+	in := "otpauth://totp/Emmanuel%20Goldstein?secret=GZRGQNKGKN4DINQ&issuer=Defcon.run&algorithm=SHA1&digits=6&period=120"
+	out, err := DeriveOtpUrl("test-server-secret", "ghost.goldstein", in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	u, err := url.Parse(out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	q := u.Query()
+	if got := q.Get("secret"); got != "XHNN23O25QAZITZ4CZTCXU4NIR6LRRCK" {
+		t.Errorf("secret = %s", got)
+	}
+	for k, want := range map[string]string{"issuer": "Defcon.run", "algorithm": "SHA1", "digits": "6", "period": "120"} {
+		if got := q.Get(k); got != want {
+			t.Errorf("%s = %s, want %s", k, got, want)
+		}
+	}
+	if !strings.Contains(out, "Emmanuel") {
+		t.Errorf("label lost: %s", out)
+	}
+	// The rewritten URL must still parse through the normal handler path.
+	if _, err := NewOTPHandler(out); err != nil {
+		t.Errorf("NewOTPHandler(rewritten): %v", err)
+	}
+}
+
+func TestDeriveOtpUrlRejectsSecretless(t *testing.T) {
+	if _, err := DeriveOtpUrl("s", "ghost.x", "otpauth://totp/Nope?issuer=Defcon.run"); err == nil {
+		t.Error("expected error for missing secret param")
+	}
+}


### PR DESCRIPTION
## What

The OTP twin of the `DeriveNodeKey` PKI munging: when `MESHTK_GHOST_KEY_SECRET` is set, each fleet entry's real TOTP secret is derived server-side and the secret committed in the YAML `OtpUrl` becomes a decoy HKDF input.

- `pkg/otp/derive.go` — `DeriveTotpSecret` = HKDF-SHA256(server secret, salt=nil, info=`meshtk-otp-seed:<fleet.Id>:<committedSecret>`, 20 bytes) → unpadded RFC 4648 base32; `DeriveOtpUrl` swaps only the `secret=` param (label/issuer/digits/period/algorithm untouched).
- `internal/app/fleet/cmd.go` — rewrite before `NewOTPHandler`. Derivation failure is **fail-closed** (nil handler + `Log.Errorf`), never a silent fallback to committed plaintext. Env unset → unchanged behavior (local dev).
- `pkg/otp/derive_test.go` — vectors shared bit-for-bit with run.human's `mesh-otp-derive` vitest (defcon.run.34 phase 67, the `/admin/ghosts` roster that reveals the derived seeds), plus domain-separation and URL-rewrite round-trip through `NewOTPHandler`.

## Rollout note

Once the fleet redeploys with this, the DC33 CTF OTP-chain rows in DynamoDB (which share the committed secrets) must be updated to the derived secrets — the run.human roster page flags STALE rows and reveals the exact values to paste.

## Testing

`go build ./...` and `go test ./...` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)