### PR TITLE
feat(fleet): server-derived covert flag codes (committed FlagCode becomes a decoy)

### DIFF
--- a/internal/app/fleet/cmd.go
+++ b/internal/app/fleet/cmd.go
@@ -104,6 +104,23 @@ func NewFleets(c *config.Config) (f *FleetCmd) {
 		} else {
 			f.OTPHandler = append(f.OTPHandler, nil)
 		}
+
+		// Derived covert flag code: substitute the DERIVED value in for the
+		// committed (decoy) FlagCode wherever it appears in the persona prompt, so
+		// the bot reveals the real code while the config keeps only the decoy —
+		// same server-secret munging as the OTP seed and the node keypairs. On a
+		// derivation error we leave the prompt untouched (the decoy shows) rather
+		// than blank the code mid-sentence; HKDF over valid inputs does not fail.
+		fc := f.Config.Fleet[i].FlagCode
+		if c.GhostKeySecret != "" && fc != "" {
+			derivedFlag, err := otp.DeriveFlagCode(c.GhostKeySecret, f.Config.Fleet[i].Id, fc)
+			if err != nil {
+				c.Log.Errorf("⚠️ flag code derivation failed for %s (decoy left in place): %v", f.Config.Fleet[i].Id, err)
+			} else {
+				f.Config.Fleet[i].OpenAISystemPrompt = strings.ReplaceAll(
+					f.Config.Fleet[i].OpenAISystemPrompt, fc, derivedFlag)
+			}
+		}
 	}
 
 	f.Pending = make(map[uint32][]*pendingReply)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -137,6 +137,12 @@ type Fleet struct {
 	OtpUrl             string     `default:""`
 	OpenAIKey          string     `default:""`
 	OpenAISystemPrompt string     `default:""`
+	// FlagCode is the COMMITTED (decoy) covert flag code — the literal that also
+	// appears in OpenAISystemPrompt. When GhostKeySecret is set, the fleet derives
+	// the real code from it (otp.DeriveFlagCode) and substitutes it into the prompt
+	// so the bot reveals the DERIVED value; the committed value in the config is a
+	// decoy, exactly like the OtpUrl seed and the node keypairs.
+	FlagCode string `default:""`
 }
 
 type Coordinate struct {

--- a/pkg/otp/derive.go
+++ b/pkg/otp/derive.go
@@ -26,6 +26,22 @@ func DeriveTotpSecret(serverSecret, fleetID, committedSecret string) (string, er
 	return base32.StdEncoding.WithPadding(base32.NoPadding).EncodeToString(key), nil
 }
 
+// DeriveFlagCode deterministically derives the REAL covert flag code from a
+// server-only secret, the entry's stable Id, and the committed (decoy) flag code.
+// Same HKDF-SHA256 construction as DeriveTotpSecret, domain-separated by a
+// distinct info label, truncated to a short typeable token: 5 bytes → 8-char
+// unpadded uppercase base32. The committed value is only an HKDF input (a decoy
+// that appears in the config/prompt), so what a repo reader sees is never what
+// the bot reveals; rotating the committed value rotates the real code.
+func DeriveFlagCode(serverSecret, fleetID, committedFlag string) (string, error) {
+	info := fmt.Sprintf("meshtk-flag-code:%s:%s", fleetID, committedFlag)
+	key, err := hkdf.Key(sha256.New, []byte(serverSecret), nil, info, 5)
+	if err != nil {
+		return "", fmt.Errorf("hkdf: %w", err)
+	}
+	return base32.StdEncoding.WithPadding(base32.NoPadding).EncodeToString(key), nil
+}
+
 // DeriveOtpUrl returns otpURL with ONLY its secret query param replaced by the
 // derived secret. Every other param (algorithm, digits, period, issuer) and the
 // label pass through, so authenticator enrollments keep their display identity.

--- a/pkg/otp/derive_test.go
+++ b/pkg/otp/derive_test.go
@@ -75,3 +75,47 @@ func TestDeriveOtpUrlRejectsSecretless(t *testing.T) {
 		t.Error("expected error for missing secret param")
 	}
 }
+
+// Shared cross-implementation vectors for the covert flag code — the SAME table
+// lives in run.human's mesh-otp-derive vitest (defcon.run.34). 5 bytes → 8-char
+// unpadded uppercase base32.
+var flagVectors = []struct {
+	serverSecret string
+	fleetID      string
+	committed    string
+	derived      string
+}{
+	{"test-server-secret", "ghost.goldstein", "hackers4evr", "WVCSNLUF"},
+	{"test-server-secret", "ghost.mudge", "0g3l33t", "FNUUESUC"},
+	{"another-secret", "ghost.condor", "fr33k3v1n", "4JCPQVLU"},
+}
+
+func TestDeriveFlagCodeVectors(t *testing.T) {
+	for _, v := range flagVectors {
+		got, err := DeriveFlagCode(v.serverSecret, v.fleetID, v.committed)
+		if err != nil {
+			t.Fatalf("DeriveFlagCode(%s): %v", v.fleetID, err)
+		}
+		if got != v.derived {
+			t.Errorf("DeriveFlagCode(%s) = %s, want %s", v.fleetID, got, v.derived)
+		}
+		if len(got) != 8 {
+			t.Errorf("DeriveFlagCode(%s) len = %d, want 8", v.fleetID, len(got))
+		}
+	}
+}
+
+func TestDeriveFlagCodeDomainSeparation(t *testing.T) {
+	a, _ := DeriveFlagCode("s", "ghost.a", "CODE")
+	b, _ := DeriveFlagCode("s", "ghost.b", "CODE")
+	c, _ := DeriveFlagCode("s2", "ghost.a", "CODE")
+	d, _ := DeriveFlagCode("s", "ghost.a", "CODE2")
+	if a == b || a == c || a == d {
+		t.Errorf("expected distinct flag codes across id/server/committed changes: %s %s %s %s", a, b, c, d)
+	}
+	// Flag code and TOTP secret must NOT collide for the same inputs (distinct info labels).
+	tot, _ := DeriveTotpSecret("s", "ghost.a", "CODE")
+	if a == tot {
+		t.Errorf("flag code and totp secret collided: %s", a)
+	}
+}


### PR DESCRIPTION
The flag-code sibling of #10. When `MESHTK_GHOST_KEY_SECRET` is set, each fleet entry's real covert flag code is derived server-side and the code committed in the config/prompt becomes a decoy.

- `pkg/otp/derive.go` — `DeriveFlagCode` = HKDF-SHA256(server secret, info=`meshtk-flag-code:<id>:<committed>`, 5 bytes) → 8-char unpadded base32. Distinct info label from the OTP seed (no collision, tested).
- `pkg/config/config.go` — new `FlagCode` field (the committed decoy = the literal that also appears in the prompt).
- `internal/app/fleet/cmd.go` — at fleet load, substitute the derived value in for the committed `FlagCode` everywhere it appears in `OpenAISystemPrompt`, so the bot reveals the derived code. Fail-soft (decoy left in place) on the practically-impossible HKDF error; env unset → unchanged.
- `pkg/otp/derive_test.go` — vectors shared bit-for-bit with run.human's `mesh-otp-derive` vitest (the CTF sync re-derives the same values).

## Rollout note
After deploy, the run.human CTF static-flag answer hashes for these personas must be updated to the derived codes (done via the defcon.run.34 rekey script, which matches by answer-hash so it catches every affected row).

## Testing
`go build ./...` and `go test ./...` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)