### PR TITLE
fix(fleet): wide ± OTP window so 30s codes survive LoRa mesh latency

### DIFF
--- a/internal/app/fleet/cmd.go
+++ b/internal/app/fleet/cmd.go
@@ -69,6 +69,12 @@ type FleetCmd struct {
 
 const BACKSTOP_GRACE_SEC = 30
 
+// otpAcceptWindowEachSide is how many TOTP periods on each side of "now" the bot
+// accepts an OTP for. At period=30 (which phone authenticator apps honor, unlike
+// 120), ±5 gives ~5.5 minutes of tolerance so a code survives the read→type→
+// LoRa-transmit→multi-hop round-trip. See otp.ValidCodesWindow.
+const otpAcceptWindowEachSide = 5
+
 func NewFleets(c *config.Config) (f *FleetCmd) {
 	f = new(FleetCmd)
 	f.Config = c
@@ -715,13 +721,18 @@ func (n *FleetCmd) FleetNodeHandler(to, from uint32, topic string, portNum mesht
 		}
 
 		if n.OTPHandler[toFleetIdx] != nil {
-			totps, err := n.OTPHandler[toFleetIdx].CalculateTOTPWithAdjacentPeriods()
+			// Accept a wide ± window (not just prev/current/next): a short-period
+			// code has to survive a slow LoRa mesh round-trip before it lands here.
+			codes, err := n.OTPHandler[toFleetIdx].ValidCodesWindow(otpAcceptWindowEachSide)
 			if err != nil {
 				n.Config.Log.Errorf("Failed to calculate TOTP: %v", err)
 				return
 			}
-			if strings.Contains(message, totps["current"]) || strings.Contains(message, totps["previous"]) || strings.Contains(message, totps["next"]) {
-				hasOTP = true
+			for _, code := range codes {
+				if strings.Contains(message, code) {
+					hasOTP = true
+					break
+				}
 			}
 		}
 

--- a/pkg/otp/totp.go
+++ b/pkg/otp/totp.go
@@ -135,6 +135,32 @@ func (tc *TOTPConfig) GenerateTOTP(timestamp time.Time) (string, error) {
 	return otpStr, nil
 }
 
+// ValidCodesWindow returns the TOTP codes for the current period plus `each`
+// periods on either side. A single ±1 window (CalculateTOTPWithAdjacentPeriods)
+// is only ~90s at period=30 — too tight for a LoRa mesh round-trip, where a code
+// is read off a phone, typed into a radio, transmitted, and relayed over several
+// hops before it reaches the bot, so a short-period code routinely expires in
+// flight. A wider window keeps period=30 (which phone authenticator apps honor,
+// unlike 120) while tolerating that latency. At period=30, each=5 accepts ~5.5
+// minutes of transit. The wider replay window is acceptable for a CTF unlock.
+func (tc *TOTPConfig) ValidCodesWindow(each int) ([]string, error) {
+	if each < 0 {
+		each = 0
+	}
+	nowUnix := time.Now().Unix()
+	start := nowUnix / int64(tc.Period) * int64(tc.Period)
+	codes := make([]string, 0, 2*each+1)
+	for i := -each; i <= each; i++ {
+		t := time.Unix(start+int64(i)*int64(tc.Period), 0)
+		code, err := tc.GenerateTOTP(t)
+		if err != nil {
+			return nil, err
+		}
+		codes = append(codes, code)
+	}
+	return codes, nil
+}
+
 // CalculateTOTPWithAdjacentPeriods calculates the TOTP for the current period,
 // as well as the previous and next periods
 func (tc *TOTPConfig) CalculateTOTPWithAdjacentPeriods() (map[string]string, error) {

--- a/pkg/otp/window_test.go
+++ b/pkg/otp/window_test.go
@@ -1,0 +1,36 @@
+package otp
+
+import "testing"
+
+func TestValidCodesWindow(t *testing.T) {
+	h, err := NewOTPHandler("otpauth://totp/T?secret=GZRGQNKGKN4DINQ&period=30&digits=6&algorithm=SHA1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// ±5 → 11 codes; the middle one equals the current adjacent "current".
+	codes, err := h.ValidCodesWindow(5)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(codes) != 11 {
+		t.Fatalf("len=%d, want 11", len(codes))
+	}
+	adj, _ := h.CalculateTOTPWithAdjacentPeriods()
+	// The window must contain prev/current/next (superset of the old behavior).
+	for _, k := range []string{"previous", "current", "next"} {
+		found := false
+		for _, c := range codes {
+			if c == adj[k] {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("window missing %s code %s", k, adj[k])
+		}
+	}
+	// each=0 → just the current period.
+	one, _ := h.ValidCodesWindow(0)
+	if len(one) != 1 || one[0] != adj["current"] {
+		t.Errorf("each=0 got %v, want [%s]", one, adj["current"])
+	}
+}


### PR DESCRIPTION
Follow-up to #10/#11 after UAT: the OTP was switched to a 30s period so phone authenticator apps honor it, but the bot only accepted prev/current/next (~90s), and a LoRa mesh round-trip (read → type → transmit → hops) routinely exceeds that, so the code expired in flight.

- `pkg/otp/totp.go` — `ValidCodesWindow(each)` returns codes for ±each periods (superset of the old prev/current/next).
- `internal/app/fleet/cmd.go` — the OTP check now matches the message against ±5 windows (~5.5 min at period=30). Keeps period=30; wider replay window is acceptable for a CTF unlock.
- Test asserts the window is a superset of the old ±1 behavior and `each=0` degrades to just the current period.

`go build ./... && go test ./...` clean.