### PR TITLE
fix(fleet): reveal placeholder {{code}} -> %CODE% (SSM-safe)

### DIFF
--- a/internal/app/fleet/challenge_test.go
+++ b/internal/app/fleet/challenge_test.go
@@ -16,7 +16,7 @@ func TestMatchesTriggerCaseInsensitive(t *testing.T) {
 }
 
 func TestRenderReveal(t *testing.T) {
-	rt := &FlagChallengeRuntime{RevealTemplate: "👻 flag: {{code}}", DerivedCode: "WVCSNLUF"}
+	rt := &FlagChallengeRuntime{RevealTemplate: "👻 flag: %CODE%", DerivedCode: "WVCSNLUF"}
 	if got := renderReveal(rt); got != "👻 flag: WVCSNLUF" {
 		t.Fatalf("renderReveal = %q", got)
 	}

--- a/internal/app/fleet/cmd.go
+++ b/internal/app/fleet/cmd.go
@@ -89,7 +89,7 @@ func matchesTrigger(rt *FlagChallengeRuntime, msg string) bool {
 }
 
 func renderReveal(rt *FlagChallengeRuntime) string {
-	return strings.ReplaceAll(rt.RevealTemplate, "{{code}}", rt.DerivedCode)
+	return strings.ReplaceAll(rt.RevealTemplate, "%CODE%", rt.DerivedCode)
 }
 
 const BACKSTOP_GRACE_SEC = 30
@@ -837,7 +837,7 @@ func (n *FleetCmd) FleetNodeHandler(to, from uint32, topic string, portNum mesht
 				}
 
 				// Deterministic covert-flag reveal: if the player raised the trigger
-				// topic, fill {{code}} with the DERIVED code server-side and reply.
+				// topic, fill %CODE% with the DERIVED code server-side and reply.
 				// The code never enters the LLM; the reveal is exempt from OUTPUT guard.
 				if toFleetIdx < len(n.Challenge) {
 					if rt := n.Challenge[toFleetIdx]; matchesTrigger(rt, message) {

--- a/pkg/config/flagchallenge.go
+++ b/pkg/config/flagchallenge.go
@@ -12,13 +12,13 @@ import (
 // revealed code is otp.DeriveFlagCode(serverSecret, fleetID, CommittedCode).
 type FlagChallenge struct {
 	Triggers       []string `json:"triggers"`
-	RevealTemplate string   `json:"revealTemplate"` // must contain "{{code}}"
+	RevealTemplate string   `json:"revealTemplate"` // must contain "%CODE%"
 	CommittedCode  string   `json:"committedCode"`
 }
 
 // ParseFlagChallenges parses the MESHTK_FLAG_CHALLENGES JSON (a map keyed by
 // fleet Id). An empty string yields an empty map (feature disabled). Every entry
-// must carry a reveal template containing the {{code}} placeholder, else the
+// must carry a reveal template containing the %CODE% placeholder, else the
 // derived code would have nowhere to land — fail loud at load, not at reveal.
 func ParseFlagChallenges(raw string) (map[string]FlagChallenge, error) {
 	out := map[string]FlagChallenge{}
@@ -29,8 +29,8 @@ func ParseFlagChallenges(raw string) (map[string]FlagChallenge, error) {
 		return nil, fmt.Errorf("MESHTK_FLAG_CHALLENGES: %w", err)
 	}
 	for id, c := range out {
-		if !strings.Contains(c.RevealTemplate, "{{code}}") {
-			return nil, fmt.Errorf("challenge %q: revealTemplate missing {{code}}", id)
+		if !strings.Contains(c.RevealTemplate, "%CODE%") {
+			return nil, fmt.Errorf("challenge %q: revealTemplate missing the %%CODE%% placeholder", id)
 		}
 	}
 	return out, nil

--- a/pkg/config/flagchallenge_test.go
+++ b/pkg/config/flagchallenge_test.go
@@ -3,7 +3,7 @@ package config
 import "testing"
 
 func TestParseFlagChallenges(t *testing.T) {
-	raw := `{"ghost.goldstein":{"triggers":["hack the planet","hacking the planet"],"revealTemplate":"You found a flag! Code: {{code}}","committedCode":"hackers4evr"}}`
+	raw := `{"ghost.goldstein":{"triggers":["hack the planet","hacking the planet"],"revealTemplate":"You found a flag! Code: %CODE%","committedCode":"hackers4evr"}}`
 	m, err := ParseFlagChallenges(raw)
 	if err != nil {
 		t.Fatalf("parse: %v", err)
@@ -15,8 +15,8 @@ func TestParseFlagChallenges(t *testing.T) {
 	if len(c.Triggers) != 2 || c.CommittedCode != "hackers4evr" {
 		t.Fatalf("bad parse: %+v", c)
 	}
-	if !contains(c.RevealTemplate, "{{code}}") {
-		t.Fatalf("reveal template missing {{code}}: %q", c.RevealTemplate)
+	if !contains(c.RevealTemplate, "%CODE%") {
+		t.Fatalf("reveal template missing placeholder: %q", c.RevealTemplate)
 	}
 }
 
@@ -30,6 +30,6 @@ func TestParseFlagChallengesEmpty(t *testing.T) {
 func TestParseFlagChallengesRejectsTemplateWithoutPlaceholder(t *testing.T) {
 	raw := `{"g":{"triggers":["x"],"revealTemplate":"no placeholder","committedCode":"c"}}`
 	if _, err := ParseFlagChallenges(raw); err == nil {
-		t.Fatal("expected error for reveal template missing {{code}}")
+		t.Fatal("expected error for reveal template missing %CODE%")
 	}
 }


### PR DESCRIPTION
AWS SSM Parameter Store rejects values containing {{}} (reserved for parameter nesting), which blocked storing the MESHTK_FLAG_CHALLENGES blob (reveal templates contained {{code}}). Switch the placeholder to %CODE% in renderReveal + ParseFlagChallenges validation. No behavior change otherwise.