### PR TITLE
feat(fleet): single-use flag-claim links — mint on reveal, static-code fallback

### DIFF
--- a/internal/app/fleet/claimlink.go
+++ b/internal/app/fleet/claimlink.go
@@ -1,0 +1,110 @@
+package fleet
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"time"
+)
+
+// Single-use flag-claim links: instead of revealing the derived flag code
+// inline (shareable forever), the bot asks run.human to mint a short-ttl
+// single-use claim nonce and DMs the claim URL. Contract:
+//
+//	POST {MESHTK_RUN_INTERNAL_URL}/api/internal/ctf/mint
+//	     x-internal-secret: {MESHTK_INTERNAL_SECRET}
+//	     {"ghost":"ghost.goldstein"}
+//	→ 200 {"nonce":"…","url":"https://…/ctf/claim?nonce=…"}
+//
+// One link per radio per unlock session (cached on the OTPUnlock record, so it
+// expires with the unlock). Any mint failure falls back to the pre-existing
+// static-code reveal — a reveal never silently dies. The url/nonce is NEVER
+// logged.
+
+// mintClaimURL asks run.human for a fresh single-use claim link for ghostId.
+// Unconfigured env or any transport/decode failure returns an error (the
+// caller falls back to the static reveal).
+func mintClaimURL(ctx context.Context, ghostId string) (string, error) {
+	base := os.Getenv("MESHTK_RUN_INTERNAL_URL")
+	secret := os.Getenv("MESHTK_INTERNAL_SECRET")
+	if base == "" || secret == "" {
+		return "", errors.New("claim-link mint not configured")
+	}
+
+	payload, _ := json.Marshal(map[string]string{"ghost": ghostId})
+	cctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(cctx, "POST", base+"/api/internal/ctf/mint", bytes.NewReader(payload))
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("content-type", "application/json")
+	req.Header.Set("x-internal-secret", secret)
+	resp, err := (&http.Client{}).Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("mint status %d", resp.StatusCode)
+	}
+	var out struct {
+		URL string `json:"url"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return "", err
+	}
+	if out.URL == "" {
+		return "", errors.New("mint returned no url")
+	}
+	return out.URL, nil
+}
+
+// getOrMintRevealURL returns this radio's claim link for the current unlock
+// session, minting AT MOST ONCE per unlock: the URL is cached on the radio's
+// OTPUnlock record (so it dies with the unlock's 1-hour expiry) and a
+// re-trigger re-sends the same link — no token farming.
+func (n *FleetCmd) getOrMintRevealURL(ctx context.Context, toFleetIdx int, from uint32) (string, error) {
+	n.OTPUnlockMux[toFleetIdx].Lock()
+	rec := n.OTPUnlocks[toFleetIdx][from]
+	cached := ""
+	if rec != nil {
+		cached = rec.RevealURL
+	}
+	n.OTPUnlockMux[toFleetIdx].Unlock()
+	if cached != "" {
+		return cached, nil
+	}
+
+	url, err := mintClaimURL(ctx, n.Config.Fleet[toFleetIdx].Id)
+	if err != nil {
+		return "", err
+	}
+	n.OTPUnlockMux[toFleetIdx].Lock()
+	if rec := n.OTPUnlocks[toFleetIdx][from]; rec != nil {
+		rec.RevealURL = url
+	}
+	n.OTPUnlockMux[toFleetIdx].Unlock()
+	return url, nil
+}
+
+// sendFlagReveal delivers the covert-flag reveal for a matched trigger: two
+// reliable DMs ("found a flag!" + the claim link), or — if minting fails for
+// any reason — the pre-existing static-code reveal so the player is never left
+// empty-handed.
+func (n *FleetCmd) sendFlagReveal(toFleetIdx int, to uint32, from uint32, topic string, rt *FlagChallengeRuntime) {
+	url, err := n.getOrMintRevealURL(context.Background(), toFleetIdx, from)
+	if err != nil {
+		if n.Config != nil && n.Config.Log != nil {
+			n.Config.Log.Errorf("claim-link mint failed (fleet %d): %v — falling back to static reveal", toFleetIdx, err)
+		}
+		n.sendPKIReplyReliable(toFleetIdx, to, from, topic, renderReveal(rt))
+		return
+	}
+	n.sendPKIReplyReliable(toFleetIdx, to, from, topic, "👻 You found a flag!")
+	n.sendPKIReplyReliable(toFleetIdx, to, from, topic, url)
+}

--- a/internal/app/fleet/claimlink_test.go
+++ b/internal/app/fleet/claimlink_test.go
@@ -1,0 +1,117 @@
+package fleet
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/whereiskurt/meshtk/pkg/config"
+)
+
+func TestMintClaimURLErrorsWhenUnconfigured(t *testing.T) {
+	t.Setenv("MESHTK_RUN_INTERNAL_URL", "")
+	t.Setenv("MESHTK_INTERNAL_SECRET", "")
+	if _, err := mintClaimURL(context.Background(), "ghost.goldstein"); err == nil {
+		t.Fatal("unset env must error (caller falls back to static reveal)")
+	}
+}
+
+func TestMintClaimURLPostsGhostWithSecretAndReturnsURL(t *testing.T) {
+	var gotSecret, gotGhost string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotSecret = r.Header.Get("x-internal-secret")
+		var body struct {
+			Ghost string `json:"ghost"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		gotGhost = body.Ghost
+		w.Write([]byte(`{"nonce":"n1","url":"https://run.defcon.run/use1/ctf/claim?nonce=n1"}`))
+	}))
+	defer srv.Close()
+	t.Setenv("MESHTK_RUN_INTERNAL_URL", srv.URL)
+	t.Setenv("MESHTK_INTERNAL_SECRET", "s3cret")
+
+	url, err := mintClaimURL(context.Background(), "ghost.goldstein")
+	if err != nil {
+		t.Fatalf("mint failed: %v", err)
+	}
+	if url != "https://run.defcon.run/use1/ctf/claim?nonce=n1" {
+		t.Errorf("wrong url: %q", url)
+	}
+	if gotSecret != "s3cret" || gotGhost != "ghost.goldstein" {
+		t.Errorf("request wrong: secret=%q ghost=%q", gotSecret, gotGhost)
+	}
+}
+
+func TestMintClaimURLErrorsOnNon200AndEmptyURL(t *testing.T) {
+	for name, handler := range map[string]http.HandlerFunc{
+		"422":       func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(422) },
+		"empty-url": func(w http.ResponseWriter, r *http.Request) { w.Write([]byte(`{"nonce":"n"}`)) },
+		"bad-json":  func(w http.ResponseWriter, r *http.Request) { w.Write([]byte(`nope`)) },
+	} {
+		srv := httptest.NewServer(handler)
+		t.Setenv("MESHTK_RUN_INTERNAL_URL", srv.URL)
+		t.Setenv("MESHTK_INTERNAL_SECRET", "s")
+		if _, err := mintClaimURL(context.Background(), "ghost.x"); err == nil {
+			t.Errorf("%s: want error", name)
+		}
+		srv.Close()
+	}
+}
+
+// One mint per radio per unlock: the second trigger returns the cached URL off
+// the OTPUnlock record without a second HTTP call, and the cache is per-radio.
+func TestGetOrMintRevealURLMintsOncePerUnlock(t *testing.T) {
+	var mints int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mints++
+		w.Write([]byte(`{"nonce":"n","url":"https://run/claim?nonce=n"}`))
+	}))
+	defer srv.Close()
+	t.Setenv("MESHTK_RUN_INTERNAL_URL", srv.URL)
+	t.Setenv("MESHTK_INTERNAL_SECRET", "s")
+
+	n := &FleetCmd{
+		Config:       &config.Config{Fleet: []config.Fleet{{Id: "ghost.goldstein"}}},
+		OTPUnlocks:   []map[uint32]*OTPUnlock{{42: {UnlockTimestamp: time.Now()}}},
+		OTPUnlockMux: []sync.RWMutex{{}},
+	}
+
+	first, err := n.getOrMintRevealURL(context.Background(), 0, 42)
+	if err != nil {
+		t.Fatalf("first mint failed: %v", err)
+	}
+	second, err := n.getOrMintRevealURL(context.Background(), 0, 42)
+	if err != nil {
+		t.Fatalf("second call failed: %v", err)
+	}
+	if first != second {
+		t.Errorf("re-trigger got a DIFFERENT link: %q vs %q", first, second)
+	}
+	if mints != 1 {
+		t.Errorf("minted %d times, want 1 (no token farming)", mints)
+	}
+	if n.OTPUnlocks[0][42].RevealURL != first {
+		t.Error("URL not cached on the unlock record")
+	}
+}
+
+func TestGetOrMintRevealURLErrorsWhenMintDown(t *testing.T) {
+	t.Setenv("MESHTK_RUN_INTERNAL_URL", "http://127.0.0.1:1") // refused
+	t.Setenv("MESHTK_INTERNAL_SECRET", "s")
+	n := &FleetCmd{
+		Config:       &config.Config{Fleet: []config.Fleet{{Id: "ghost.goldstein"}}},
+		OTPUnlocks:   []map[uint32]*OTPUnlock{{42: {UnlockTimestamp: time.Now()}}},
+		OTPUnlockMux: []sync.RWMutex{{}},
+	}
+	if _, err := n.getOrMintRevealURL(context.Background(), 0, 42); err == nil {
+		t.Fatal("mint transport failure must surface as error (fallback path)")
+	}
+	if n.OTPUnlocks[0][42].RevealURL != "" {
+		t.Error("failed mint must not cache anything")
+	}
+}

--- a/internal/app/fleet/cmd.go
+++ b/internal/app/fleet/cmd.go
@@ -27,6 +27,10 @@ import (
 type OTPUnlock struct {
 	UnlockTimestamp time.Time
 	UnlockMessage   string
+	// RevealURL caches this unlock session's single-use flag-claim link so a
+	// re-trigger re-sends the SAME link (one mint per radio per unlock — no
+	// token farming). Dies with the record's 1-hour expiry. See claimlink.go.
+	RevealURL string
 }
 
 type FleetCmd struct {
@@ -837,12 +841,14 @@ func (n *FleetCmd) FleetNodeHandler(to, from uint32, topic string, portNum mesht
 				}
 
 				// Deterministic covert-flag reveal: if the player raised the trigger
-				// topic, fill %CODE% with the DERIVED code server-side and reply.
-				// The code never enters the LLM; the reveal is exempt from OUTPUT guard.
+				// topic, send a single-use claim link (minted once per unlock; a
+				// mint failure falls back to the %CODE% static reveal — see
+				// claimlink.go). The code never enters the LLM; the reveal is
+				// exempt from OUTPUT guard.
 				if toFleetIdx < len(n.Challenge) {
 					if rt := n.Challenge[toFleetIdx]; matchesTrigger(rt, message) {
-						n.Config.Log.Infof("flag trigger matched (fleet %d) from %d — revealing derived code", toFleetIdx, from)
-						n.sendPKIReplyReliable(toFleetIdx, to, from, topic, renderReveal(rt))
+						n.Config.Log.Infof("flag trigger matched (fleet %d) from %d — sending claim reveal", toFleetIdx, from)
+						n.sendFlagReveal(toFleetIdx, to, from, topic, rt)
 						return
 					}
 				}

--- a/internal/app/fleet/reply_retry_test.go
+++ b/internal/app/fleet/reply_retry_test.go
@@ -160,16 +160,18 @@ func TestSendSpreadCountOneDoesNotRetry(t *testing.T) {
 func funcBody(t *testing.T, name string) (*ast.FuncDecl, *token.FileSet) {
 	t.Helper()
 	fset := token.NewFileSet()
-	f, err := parser.ParseFile(fset, "cmd.go", nil, 0)
-	if err != nil {
-		t.Fatalf("parse cmd.go: %v", err)
-	}
-	for _, d := range f.Decls {
-		if fd, ok := d.(*ast.FuncDecl); ok && fd.Name.Name == name {
-			return fd, fset
+	for _, file := range []string{"cmd.go", "claimlink.go"} {
+		f, err := parser.ParseFile(fset, file, nil, 0)
+		if err != nil {
+			t.Fatalf("parse %s: %v", file, err)
+		}
+		for _, d := range f.Decls {
+			if fd, ok := d.(*ast.FuncDecl); ok && fd.Name.Name == name {
+				return fd, fset
+			}
 		}
 	}
-	t.Fatalf("func %s not found in cmd.go", name)
+	t.Fatalf("func %s not found in cmd.go/claimlink.go", name)
 	return nil, nil
 }
 
@@ -203,16 +205,33 @@ func TestLyricsChatDoesNotUseReliableRetry(t *testing.T) {
 
 // The one-shot reply paths all live in FleetNodeHandler: otp_success,
 // otp_failure (non-unlocking branch), and — in the unlocked branch — the
-// guardrail-block refusal and the deterministic flag reveal. Every one of them
-// must go through the reliable wrapper.
+// guardrail-block refusal. Every one of them must go through the reliable
+// wrapper. (The deterministic flag reveal moved into sendFlagReveal — covered
+// by TestFlagRevealUsesReliableRetry below.)
 func TestOneShotReplyPathsUseReliableRetry(t *testing.T) {
 	fd, _ := funcBody(t, "FleetNodeHandler")
 	calls := calleeNames(fd)
-	if got := calls["sendPKIReplyReliable"]; got != 4 {
-		t.Errorf("FleetNodeHandler has %d sendPKIReplyReliable calls, want 4 (otp_success, otp_failure, guard-refusal, flag-reveal)", got)
+	if got := calls["sendPKIReplyReliable"]; got != 3 {
+		t.Errorf("FleetNodeHandler has %d sendPKIReplyReliable calls, want 3 (otp_success, otp_failure, guard-refusal)", got)
+	}
+	if calls["sendFlagReveal"] == 0 {
+		t.Error("FleetNodeHandler no longer routes the flag reveal through sendFlagReveal")
 	}
 	if got := calls["sendPKIReply"]; got != 0 {
 		t.Errorf("FleetNodeHandler still has %d bare sendPKIReply calls; one-shot replies must retry", got)
+	}
+}
+
+// Every send inside the claim-link reveal (found-a-flag + link, and the
+// mint-failure static fallback) is a one-shot reply and must retry reliably.
+func TestFlagRevealUsesReliableRetry(t *testing.T) {
+	fd, _ := funcBody(t, "sendFlagReveal")
+	calls := calleeNames(fd)
+	if got := calls["sendPKIReplyReliable"]; got != 3 {
+		t.Errorf("sendFlagReveal has %d sendPKIReplyReliable calls, want 3 (fallback, found-a-flag, link)", got)
+	}
+	if got := calls["sendPKIReply"]; got != 0 {
+		t.Errorf("sendFlagReveal has %d bare sendPKIReply calls; one-shot replies must retry", got)
 	}
 }
 

--- a/internal/app/fleet/request_dedup_test.go
+++ b/internal/app/fleet/request_dedup_test.go
@@ -95,7 +95,7 @@ func TestRetransmitGuardRunsBeforeChatbotPaths(t *testing.T) {
 			if guardPos == 0 {
 				guardPos = int(call.Pos())
 			}
-		case "sendPKIReplyReliable", "handleLyricsChat", "handleLLMChat":
+		case "sendPKIReplyReliable", "sendFlagReveal", "handleLyricsChat", "handleLLMChat":
 			if firstReplyPos == 0 {
 				firstReplyPos = int(call.Pos())
 			}


### PR DESCRIPTION
Companion to whereiskurt/defcon.run.34#1001. On a matched flag trigger, the ghost sends two reliable DMs (found-a-flag + a magic-link claim URL minted from run.human's internal endpoint) instead of the shareable static derived code.

- One mint per radio per unlock (URL cached on the OTPUnlock record; re-trigger re-sends the SAME link)
- Mint failure of any kind falls back to the existing %CODE% static reveal
- url/nonce never logged
- go build/vet/test green; structural reliable-reply tests updated for the moved reveal

🤖 Generated with [Claude Code](https://claude.com/claude-code)