### PR TITLE
feat: radio-verification OTP delivery (queue poller + PKI DM from map node)

### DIFF
--- a/internal/app/fleet/cmd.go
+++ b/internal/app/fleet/cmd.go
@@ -306,6 +306,12 @@ func (f *FleetCmd) Simulate(cmd *cobra.Command, argz []string) {
 		f.MqttClient = append(f.MqttClient, mqttClient)
 	}
 
+	// OTP delivery poller: drain run.human's MeshOtpPending queue and PKI-DM
+	// verification codes to devices from the NodeInfo (map) node identity.
+	if store := f.buildOtpStore(); store != nil && len(f.MqttClient) > 0 {
+		go f.startOtpPoller(context.Background(), store, otpPollInterval)
+	}
+
 	terminate := make(chan os.Signal, 1)
 
 	signal.Notify(terminate, syscall.SIGINT, syscall.SIGTERM)

--- a/internal/app/fleet/otpsend.go
+++ b/internal/app/fleet/otpsend.go
@@ -1,0 +1,196 @@
+package fleet
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/whereiskurt/meshtk/internal/otpqueue"
+	meshtastic "github.com/whereiskurt/meshtk/protos/meshtastic/generated"
+)
+
+// OTP delivery: run.human's manual radio add/resend enqueues a MeshOtpPending
+// item; this poller drains the queue and PKI-DMs the verification code to the
+// device from the NodeInfo (map) node identity. On success the item is deleted
+// and codeSentAt is stamped on the MeshRadio row so the site shows "code sent".
+
+const otpPollInterval = 20 * time.Second
+
+// otpSendDeps is the seam between queue mechanics (tested with fakes) and the
+// live MQTT/keycache wiring (fleetOtpDeps below).
+type otpSendDeps interface {
+	// ResolvePubKeyHex returns the recipient's X25519 pubkey as 0x-hex:
+	// user-supplied on the item → authoritative MeshRadio row → NODEINFO-observed.
+	ResolvePubKeyHex(item otpqueue.Item) (string, bool)
+	SendCode(toNodeNum uint32, pubKeyHex, code string) error
+	NowMs() int64
+}
+
+// processOtpQueue runs one poll pass. Item lifecycle: expired or attempt-capped
+// → reap; no pubkey yet → leave queued (the radio may announce NODEINFO later);
+// send OK → delete + stamp codeSentAt; send failed → bump attempts and retry
+// next pass.
+func processOtpQueue(ctx context.Context, deps otpSendDeps, store otpqueue.Store, logger *log.Logger) {
+	items, err := store.List(ctx)
+	if err != nil {
+		logger.Errorf("otp: queue list failed: %v", err)
+		return
+	}
+	if len(items) == 0 {
+		return
+	}
+
+	var sent, waiting, reaped, failed int
+	for _, it := range items {
+		switch {
+		case deps.NowMs()-it.CreatedAt > otpqueue.MaxAgeMs:
+			reaped++
+			if err := store.Delete(ctx, it.NodeID); err != nil {
+				logger.Errorf("otp: reap expired %s failed: %v", it.NodeID, err)
+			}
+		case it.Attempts >= otpqueue.MaxAttempts:
+			reaped++
+			logger.Errorf("otp: giving up on %s after %d failed publishes", it.NodeID, it.Attempts)
+			if err := store.Delete(ctx, it.NodeID); err != nil {
+				logger.Errorf("otp: reap capped %s failed: %v", it.NodeID, err)
+			}
+		default:
+			pubKey, ok := deps.ResolvePubKeyHex(it)
+			if !ok {
+				waiting++
+				continue
+			}
+			if err := deps.SendCode(it.NodeNum, pubKey, it.Code); err != nil {
+				failed++
+				logger.Errorf("otp: send to %s failed (attempt %d): %v", it.NodeID, it.Attempts+1, err)
+				if err := store.BumpAttempts(ctx, it.NodeID, it.Attempts+1); err != nil {
+					logger.Errorf("otp: bump %s failed: %v", it.NodeID, err)
+				}
+				continue
+			}
+			sent++
+			if err := store.Delete(ctx, it.NodeID); err != nil {
+				logger.Errorf("otp: delete sent %s failed (device may see a duplicate code): %v", it.NodeID, err)
+			}
+			if err := store.MarkRadioCodeSent(ctx, it.NodeNum, deps.NowMs()); err != nil {
+				logger.Errorf("otp: codeSentAt stamp for %s failed: %v", it.NodeID, err)
+			}
+			logger.Infof("otp: verification code delivered to %s", it.NodeID)
+		}
+	}
+	logger.Infof("otp: pass done sent=%d waiting=%d reaped=%d failed=%d", sent, waiting, reaped, failed)
+}
+
+// pkiTopicFor derives the SENDER's gateway PKI topic from the NodeInfo channel
+// topic: "msh/US/2/e/dc.run" + !dc340001 -> "msh/US/2/e/PKI/!dc340001".
+// Publishing on the sender's own gateway topic is REQUIRED: devices drop
+// messages arriving on their own gateway topic as self-echo (the Phase 66
+// ghost-reply field bug — see buildPKIReply).
+func pkiTopicFor(nodeInfoTopic string, sender uint32) string {
+	base := nodeInfoTopic
+	if i := strings.LastIndex(base, "/"); i >= 0 {
+		base = base[:i]
+	}
+	return fmt.Sprintf("%s/PKI/!%08x", base, sender)
+}
+
+func parseNodeID(id string) (uint32, error) {
+	v, err := strconv.ParseUint(strings.TrimPrefix(id, "!"), 16, 32)
+	if err != nil {
+		return 0, fmt.Errorf("parse node id %q: %w", id, err)
+	}
+	return uint32(v), nil
+}
+
+// fleetOtpDeps is the production otpSendDeps: resolves recipient keys through
+// the same chain the ghosts use, and sends from the NodeInfo (map) identity
+// via the first fleet client's connection.
+type fleetOtpDeps struct {
+	f *FleetCmd
+}
+
+func (d *fleetOtpDeps) ResolvePubKeyHex(item otpqueue.Item) (string, bool) {
+	if item.PublicKey != "" {
+		return item.PublicKey, true
+	}
+	client := d.f.MqttClient[0]
+	if hexKey, err := client.ResolveSenderPubKey(item.NodeNum); err == nil && hexKey != "" {
+		return hexKey, true
+	}
+	return client.ObservedPubKey(item.NodeNum)
+}
+
+func (d *fleetOtpDeps) SendCode(toNodeNum uint32, pubKeyHex, code string) error {
+	cfg := d.f.Config
+	client := d.f.MqttClient[0]
+
+	sender, err := parseNodeID(cfg.NodeInfo.ClientId)
+	if err != nil {
+		return err
+	}
+	senderPriv, err := client.ParseHexKey(cfg.NodeInfo.PKI.PrivateKey)
+	if err != nil {
+		return fmt.Errorf("nodeinfo private key: %w", err)
+	}
+	recipientPub, err := client.ParseHexKey(pubKeyHex)
+	if err != nil {
+		return fmt.Errorf("recipient pubkey: %w", err)
+	}
+
+	payload := fmt.Sprintf("run.defcon.run radio verification code: %s", code)
+	envelope, err := client.BuildPKIMessage(sender, toNodeNum,
+		meshtastic.PortNum_TEXT_MESSAGE_APP, []byte(payload), senderPriv, recipientPub)
+	if err != nil {
+		return err
+	}
+	return client.PublishEnvelopeBytes(pkiTopicFor(cfg.NodeInfo.Topic, sender), envelope)
+}
+
+func (d *fleetOtpDeps) NowMs() int64 { return time.Now().UnixMilli() }
+
+// buildOtpStore mirrors buildKeyResolver's config handling: same table/region/
+// endpoint block, nil (with a warn) on failure so the fleet boots regardless.
+func (f *FleetCmd) buildOtpStore() otpqueue.Store {
+	kc := f.Config.Server.KeyCache
+	if kc.TableName == "" {
+		return nil
+	}
+	store, err := otpqueue.NewDynamoDBStore(kc.TableName, kc.TableRegion, kc.DynamoDBEndpoint)
+	if err != nil {
+		if f.Config.Log != nil {
+			f.Config.Log.Warnf("otp: queue store unavailable, OTP delivery disabled: %v", err)
+		}
+		return nil
+	}
+	return store
+}
+
+// startOtpPoller drains the queue every pollEvery until ctx ends. A panic in a
+// pass is logged and the loop continues — OTP delivery must never take down
+// the ghosts.
+func (f *FleetCmd) startOtpPoller(ctx context.Context, store otpqueue.Store, pollEvery time.Duration) {
+	deps := &fleetOtpDeps{f: f}
+	logger := f.Config.Log
+	logger.Infof("otp: delivery poller started (every %v, sender %s)", pollEvery, f.Config.NodeInfo.ClientId)
+
+	ticker := time.NewTicker(pollEvery)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			func() {
+				defer func() {
+					if r := recover(); r != nil {
+						logger.Errorf("otp: poll pass panicked: %v", r)
+					}
+				}()
+				processOtpQueue(ctx, deps, store, logger)
+			}()
+		}
+	}
+}

--- a/internal/app/fleet/otpsend_test.go
+++ b/internal/app/fleet/otpsend_test.go
@@ -1,0 +1,160 @@
+package fleet
+
+import (
+	"context"
+	"errors"
+	"io"
+	"testing"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/whereiskurt/meshtk/internal/otpqueue"
+)
+
+func testLogger() *log.Logger {
+	l := log.New()
+	l.SetOutput(io.Discard)
+	return l
+}
+
+type fakeOtpStore struct {
+	items    []otpqueue.Item
+	deleted  []string
+	bumped   map[string]int
+	marked   []uint32
+	listErr  error
+}
+
+func newFakeOtpStore(items ...otpqueue.Item) *fakeOtpStore {
+	return &fakeOtpStore{items: items, bumped: map[string]int{}}
+}
+
+func (f *fakeOtpStore) List(context.Context) ([]otpqueue.Item, error) { return f.items, f.listErr }
+func (f *fakeOtpStore) Delete(_ context.Context, nodeID string) error {
+	f.deleted = append(f.deleted, nodeID)
+	return nil
+}
+func (f *fakeOtpStore) BumpAttempts(_ context.Context, nodeID string, attempts int) error {
+	f.bumped[nodeID] = attempts
+	return nil
+}
+func (f *fakeOtpStore) MarkRadioCodeSent(_ context.Context, nodeNum uint32, _ int64) error {
+	f.marked = append(f.marked, nodeNum)
+	return nil
+}
+
+type fakeOtpDeps struct {
+	pubkeys map[uint32]string
+	sendErr error
+	sent    []uint32
+	nowMs   int64
+}
+
+func (f *fakeOtpDeps) ResolvePubKeyHex(item otpqueue.Item) (string, bool) {
+	if item.PublicKey != "" {
+		return item.PublicKey, true
+	}
+	k, ok := f.pubkeys[item.NodeNum]
+	return k, ok
+}
+func (f *fakeOtpDeps) SendCode(toNodeNum uint32, pubKeyHex, code string) error {
+	if f.sendErr != nil {
+		return f.sendErr
+	}
+	f.sent = append(f.sent, toNodeNum)
+	return nil
+}
+func (f *fakeOtpDeps) NowMs() int64 { return f.nowMs }
+
+func item(nodeID string, nodeNum uint32, createdAt int64, attempts int) otpqueue.Item {
+	return otpqueue.Item{NodeID: nodeID, NodeNum: nodeNum, Code: "123456", CreatedAt: createdAt, Attempts: attempts}
+}
+
+const nowMs = int64(1_784_969_443_000)
+
+func TestOtpExpiredItemReapedUnsent(t *testing.T) {
+	store := newFakeOtpStore(item("!433d1cec", 1128078572, nowMs-otpqueue.MaxAgeMs-1, 0))
+	deps := &fakeOtpDeps{nowMs: nowMs, pubkeys: map[uint32]string{1128078572: "0xkey"}}
+
+	processOtpQueue(context.Background(), deps, store, testLogger())
+
+	if len(deps.sent) != 0 {
+		t.Fatal("expired item must not send")
+	}
+	if len(store.deleted) != 1 || store.deleted[0] != "!433d1cec" {
+		t.Fatalf("expired item must be reaped: %+v", store.deleted)
+	}
+}
+
+func TestOtpNoPubkeyStaysQueued(t *testing.T) {
+	store := newFakeOtpStore(item("!433d1cec", 1128078572, nowMs, 0))
+	deps := &fakeOtpDeps{nowMs: nowMs} // no key anywhere
+
+	processOtpQueue(context.Background(), deps, store, testLogger())
+
+	if len(deps.sent) != 0 || len(store.deleted) != 0 || len(store.bumped) != 0 {
+		t.Fatalf("keyless item must be left untouched: sent=%v deleted=%v bumped=%v",
+			deps.sent, store.deleted, store.bumped)
+	}
+}
+
+func TestOtpSuccessSendsDeletesMarks(t *testing.T) {
+	store := newFakeOtpStore(item("!433d1cec", 1128078572, nowMs, 0))
+	deps := &fakeOtpDeps{nowMs: nowMs, pubkeys: map[uint32]string{1128078572: "0xkey"}}
+
+	processOtpQueue(context.Background(), deps, store, testLogger())
+
+	if len(deps.sent) != 1 || deps.sent[0] != 1128078572 {
+		t.Fatalf("expected one send: %+v", deps.sent)
+	}
+	if len(store.deleted) != 1 || store.deleted[0] != "!433d1cec" {
+		t.Fatalf("sent item must be deleted: %+v", store.deleted)
+	}
+	if len(store.marked) != 1 || store.marked[0] != 1128078572 {
+		t.Fatalf("sent item must stamp codeSentAt: %+v", store.marked)
+	}
+}
+
+func TestOtpSendFailureBumpsAndSurvives(t *testing.T) {
+	store := newFakeOtpStore(item("!433d1cec", 1128078572, nowMs, 2))
+	deps := &fakeOtpDeps{nowMs: nowMs, pubkeys: map[uint32]string{1128078572: "0xkey"}, sendErr: errors.New("broker down")}
+
+	processOtpQueue(context.Background(), deps, store, testLogger())
+
+	if len(store.deleted) != 0 {
+		t.Fatal("failed item must survive")
+	}
+	if store.bumped["!433d1cec"] != 3 {
+		t.Fatalf("attempts must bump to 3: %+v", store.bumped)
+	}
+}
+
+func TestOtpAttemptsCapReaps(t *testing.T) {
+	store := newFakeOtpStore(item("!433d1cec", 1128078572, nowMs, otpqueue.MaxAttempts))
+	deps := &fakeOtpDeps{nowMs: nowMs, pubkeys: map[uint32]string{1128078572: "0xkey"}}
+
+	processOtpQueue(context.Background(), deps, store, testLogger())
+
+	if len(deps.sent) != 0 {
+		t.Fatal("capped item must not send")
+	}
+	if len(store.deleted) != 1 {
+		t.Fatalf("capped item must be reaped: %+v", store.deleted)
+	}
+}
+
+func TestPkiTopicForStripsChannelSegment(t *testing.T) {
+	got := pkiTopicFor("msh/US/2/e/dc.run", 0xdc340001)
+	if got != "msh/US/2/e/PKI/!dc340001" {
+		t.Fatalf("bad topic: %q", got)
+	}
+}
+
+func TestParseNodeID(t *testing.T) {
+	n, err := parseNodeID("!dc340001")
+	if err != nil || n != 0xdc340001 {
+		t.Fatalf("parse failed: %v %x", err, n)
+	}
+	if _, err := parseNodeID("!zzz"); err == nil {
+		t.Fatal("garbage must error")
+	}
+}

--- a/internal/mqtt/mqtt.go
+++ b/internal/mqtt/mqtt.go
@@ -236,6 +236,12 @@ func (c *MqttClient) dispatcher(_ mqtt.Client, msg mqtt.Message) {
 		return
 	}
 
+	// Every NODEINFO flowing past feeds the observed-pubkey map (OTP delivery's
+	// last-resort recipient key).
+	if portNum == meshtastic.PortNum_NODEINFO_APP {
+		noteObservedNodeInfo(from, payload)
+	}
+
 	//c.log.Tracef(`{'from': %v, 'topic': '%v', 'portNum': %v, 'isEncrypted': %v, 'payload': '0x%x'}`, from, topic, portNum, isEncrypted, payload)
 	c.messageHandler(to, from, topic, portNum, payload)
 }

--- a/internal/mqtt/observed_pubkey.go
+++ b/internal/mqtt/observed_pubkey.go
@@ -1,0 +1,39 @@
+package mqtt
+
+import (
+	"fmt"
+	"sync"
+
+	meshtastic "github.com/whereiskurt/meshtk/protos/meshtastic/generated"
+	"google.golang.org/protobuf/proto"
+)
+
+// observedPubKeys remembers the newest pubkey each node announced via
+// NODEINFO, process-wide (mirrors pubKeyCache): every client subscription
+// feeds one shared map, so a key observed on any topic is visible to all.
+// Consumed by the OTP delivery poller as its last-resort recipient key when
+// neither the user nor the authoritative MeshRadio row supplied one.
+var observedPubKeys sync.Map // map[uint32]string ("0x" + 64 hex)
+
+// noteObservedNodeInfo records the announced pubkey from a NODEINFO payload.
+// Malformed payloads and keyless announcements are ignored silently — this
+// sits on the hot dispatch path.
+func noteObservedNodeInfo(from uint32, payload []byte) {
+	user := new(meshtastic.User)
+	if err := proto.Unmarshal(payload, user); err != nil {
+		return
+	}
+	if pk := user.GetPublicKey(); len(pk) == 32 {
+		observedPubKeys.Store(from, fmt.Sprintf("0x%x", pk))
+	}
+}
+
+// ObservedPubKey returns the pubkey last announced via NODEINFO by nodeNum as
+// ParseHexKey-ready 0x-hex, or ("", false) when the node is unknown/keyless.
+func (c *MqttClient) ObservedPubKey(nodeNum uint32) (string, bool) {
+	v, ok := observedPubKeys.Load(nodeNum)
+	if !ok {
+		return "", false
+	}
+	return v.(string), true
+}

--- a/internal/mqtt/observed_pubkey_test.go
+++ b/internal/mqtt/observed_pubkey_test.go
@@ -1,0 +1,58 @@
+package mqtt
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+
+	meshtastic "github.com/whereiskurt/meshtk/protos/meshtastic/generated"
+	"google.golang.org/protobuf/proto"
+)
+
+// The OTP delivery poller's last-resort pubkey source is "whatever the radio
+// itself announced via NODEINFO" — these lock the observation path end to end:
+// a NODEINFO payload flowing through the dispatch must surface via
+// ObservedPubKey as ParseHexKey-ready 0x-hex.
+func TestObservedPubKeyFromNodeInfo(t *testing.T) {
+	c := &MqttClient{}
+
+	key := bytes.Repeat([]byte{0xab}, 32)
+	payload, err := proto.Marshal(&meshtastic.User{
+		Id:        "!7573fe10",
+		LongName:  "Shannon_Overwatch",
+		ShortName: "sha4",
+		PublicKey: key,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	noteObservedNodeInfo(0x7573fe10, payload)
+
+	got, ok := c.ObservedPubKey(0x7573fe10)
+	if !ok {
+		t.Fatal("expected observed pubkey")
+	}
+	if want := fmt.Sprintf("0x%x", key); got != want {
+		t.Fatalf("got %q want %q", got, want)
+	}
+}
+
+func TestObservedPubKeyMisses(t *testing.T) {
+	c := &MqttClient{}
+
+	if _, ok := c.ObservedPubKey(0xdeadbeef); ok {
+		t.Fatal("unknown node must miss")
+	}
+
+	// A keyless NODEINFO (or garbage payload) must not store anything.
+	payload, _ := proto.Marshal(&meshtastic.User{Id: "!00000001", LongName: "nokey"})
+	noteObservedNodeInfo(0x00000001, payload)
+	if _, ok := c.ObservedPubKey(0x00000001); ok {
+		t.Fatal("keyless NODEINFO must not register")
+	}
+	noteObservedNodeInfo(0x00000002, []byte{0xff, 0xff, 0x01})
+	if _, ok := c.ObservedPubKey(0x00000002); ok {
+		t.Fatal("garbage payload must not register")
+	}
+}

--- a/internal/otpqueue/key_parity_test.go
+++ b/internal/otpqueue/key_parity_test.go
@@ -1,0 +1,28 @@
+package otpqueue
+
+import "testing"
+
+// LOCKED cross-language contract with run.human's
+// mesh-otp-pending-key-parity.test.ts — same fixture nodeId !433d1cec
+// (nodeNum 1128078572), byte-identical strings. Drift here silently strands
+// every OTP delivery (Query matches nothing) — never change one side alone.
+func TestQueueKeyParity(t *testing.T) {
+	if queuePK != "$run#queue_otp" {
+		t.Fatalf("queue pk drifted: %q", queuePK)
+	}
+	if got := queueSK("!433d1cec"); got != "$meshotppending_1#nodeid_!433d1cec" {
+		t.Fatalf("queue sk drifted: %q", got)
+	}
+	if queueSKPrefix != "$meshotppending_1#nodeid_" {
+		t.Fatalf("sk prefix drifted: %q", queueSKPrefix)
+	}
+}
+
+// Mirrors keycache's parity lock on the MeshRadio primary key — the poller
+// stamps codeSentAt onto this row after a successful send.
+func TestMeshRadioKeyParity(t *testing.T) {
+	k := meshRadioKey(1128078572) // 0x433d1cec
+	if k.PK != "$run#nodeid_!433d1cec" || k.SK != "$meshradio_1" {
+		t.Fatalf("MeshRadio key drifted: %+v", k)
+	}
+}

--- a/internal/otpqueue/store.go
+++ b/internal/otpqueue/store.go
@@ -1,0 +1,156 @@
+package otpqueue
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+)
+
+// DynamoDBAPI is the subset of DynamoDB client methods used by DynamoDBStore.
+// Query (single constant partition — never a Scan), plus the two writes.
+type DynamoDBAPI interface {
+	Query(ctx context.Context, params *dynamodb.QueryInput, optFns ...func(*dynamodb.Options)) (*dynamodb.QueryOutput, error)
+	DeleteItem(ctx context.Context, params *dynamodb.DeleteItemInput, optFns ...func(*dynamodb.Options)) (*dynamodb.DeleteItemOutput, error)
+	UpdateItem(ctx context.Context, params *dynamodb.UpdateItemInput, optFns ...func(*dynamodb.Options)) (*dynamodb.UpdateItemOutput, error)
+}
+
+// DynamoDBStore implements Store against the shared run-human-electro table.
+// Construction mirrors keycache.NewDynamoDBStore (same table/region/endpoint
+// config block).
+type DynamoDBStore struct {
+	client    DynamoDBAPI
+	tableName string
+}
+
+// NewDynamoDBStore creates a DynamoDBStore with a real AWS DynamoDB client.
+// If endpoint is non-empty, it overrides the default endpoint (local dev).
+func NewDynamoDBStore(tableName, region, endpoint string) (*DynamoDBStore, error) {
+	cfg, err := config.LoadDefaultConfig(context.TODO())
+	if err != nil {
+		return nil, fmt.Errorf("load aws config: %w", err)
+	}
+
+	opts := []func(*dynamodb.Options){
+		func(o *dynamodb.Options) {
+			o.Region = region
+		},
+	}
+	if endpoint != "" {
+		opts = append(opts, func(o *dynamodb.Options) {
+			o.BaseEndpoint = aws.String(endpoint)
+		})
+	}
+
+	return &DynamoDBStore{
+		client:    dynamodb.NewFromConfig(cfg, opts...),
+		tableName: tableName,
+	}, nil
+}
+
+// NewDynamoDBStoreWithClient creates a DynamoDBStore with a provided client (tests).
+func NewDynamoDBStoreWithClient(client DynamoDBAPI, tableName string) *DynamoDBStore {
+	return &DynamoDBStore{client: client, tableName: tableName}
+}
+
+func (s *DynamoDBStore) queueKey(nodeID string) map[string]types.AttributeValue {
+	return map[string]types.AttributeValue{
+		"pk": &types.AttributeValueMemberS{Value: queuePK},
+		"sk": &types.AttributeValueMemberS{Value: queueSK(nodeID)},
+	}
+}
+
+// List returns every pending OTP delivery. The queue partition is tiny, but
+// pagination is followed anyway.
+func (s *DynamoDBStore) List(ctx context.Context) ([]Item, error) {
+	var items []Item
+	var startKey map[string]types.AttributeValue
+
+	for {
+		out, err := s.client.Query(ctx, &dynamodb.QueryInput{
+			TableName:              aws.String(s.tableName),
+			KeyConditionExpression: aws.String("pk = :pk AND begins_with(sk, :skp)"),
+			ExpressionAttributeValues: map[string]types.AttributeValue{
+				":pk":  &types.AttributeValueMemberS{Value: queuePK},
+				":skp": &types.AttributeValueMemberS{Value: queueSKPrefix},
+			},
+			ExclusiveStartKey: startKey,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("otpqueue query: %w", err)
+		}
+		for _, raw := range out.Items {
+			var it Item
+			if err := attributevalue.UnmarshalMap(raw, &it); err != nil {
+				return nil, fmt.Errorf("otpqueue unmarshal: %w", err)
+			}
+			items = append(items, it)
+		}
+		if len(out.LastEvaluatedKey) == 0 {
+			break
+		}
+		startKey = out.LastEvaluatedKey
+	}
+	return items, nil
+}
+
+// Delete removes a queue item (idempotent at the DynamoDB level).
+func (s *DynamoDBStore) Delete(ctx context.Context, nodeID string) error {
+	_, err := s.client.DeleteItem(ctx, &dynamodb.DeleteItemInput{
+		TableName: aws.String(s.tableName),
+		Key:       s.queueKey(nodeID),
+	})
+	if err != nil {
+		return fmt.Errorf("otpqueue delete %s: %w", nodeID, err)
+	}
+	return nil
+}
+
+// BumpAttempts records a failed publish attempt on the queue item.
+func (s *DynamoDBStore) BumpAttempts(ctx context.Context, nodeID string, attempts int) error {
+	_, err := s.client.UpdateItem(ctx, &dynamodb.UpdateItemInput{
+		TableName:        aws.String(s.tableName),
+		Key:              s.queueKey(nodeID),
+		UpdateExpression: aws.String("SET attempts = :a"),
+		ExpressionAttributeValues: map[string]types.AttributeValue{
+			":a": &types.AttributeValueMemberN{Value: fmt.Sprintf("%d", attempts)},
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("otpqueue bump %s: %w", nodeID, err)
+	}
+	return nil
+}
+
+// MarkRadioCodeSent stamps codeSentAt on the authoritative MeshRadio row so
+// run.human's UI flips from "waiting" to "code sent". The condition guards
+// against minting an orphan half-row when the radio was deleted mid-flight —
+// that race is expected and silently ignored.
+func (s *DynamoDBStore) MarkRadioCodeSent(ctx context.Context, nodeNum uint32, sentAtMs int64) error {
+	k := meshRadioKey(nodeNum)
+	_, err := s.client.UpdateItem(ctx, &dynamodb.UpdateItemInput{
+		TableName: aws.String(s.tableName),
+		Key: map[string]types.AttributeValue{
+			"pk": &types.AttributeValueMemberS{Value: k.PK},
+			"sk": &types.AttributeValueMemberS{Value: k.SK},
+		},
+		ConditionExpression: aws.String("attribute_exists(pk)"),
+		UpdateExpression:    aws.String("SET codeSentAt = :t"),
+		ExpressionAttributeValues: map[string]types.AttributeValue{
+			":t": &types.AttributeValueMemberN{Value: fmt.Sprintf("%d", sentAtMs)},
+		},
+	})
+	if err != nil {
+		var ccf *types.ConditionalCheckFailedException
+		if errors.As(err, &ccf) {
+			return nil // radio row deleted mid-flight — not an error
+		}
+		return fmt.Errorf("otpqueue mark sent !%08x: %w", nodeNum, err)
+	}
+	return nil
+}

--- a/internal/otpqueue/store_test.go
+++ b/internal/otpqueue/store_test.go
@@ -1,0 +1,130 @@
+package otpqueue
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+)
+
+type fakeDDB struct {
+	queryOut   *dynamodb.QueryOutput
+	queryErr   error
+	lastQuery  *dynamodb.QueryInput
+	lastDelete *dynamodb.DeleteItemInput
+	lastUpdate *dynamodb.UpdateItemInput
+	updateErr  error
+}
+
+func (f *fakeDDB) Query(_ context.Context, in *dynamodb.QueryInput, _ ...func(*dynamodb.Options)) (*dynamodb.QueryOutput, error) {
+	f.lastQuery = in
+	if f.queryErr != nil {
+		return nil, f.queryErr
+	}
+	return f.queryOut, nil
+}
+
+func (f *fakeDDB) DeleteItem(_ context.Context, in *dynamodb.DeleteItemInput, _ ...func(*dynamodb.Options)) (*dynamodb.DeleteItemOutput, error) {
+	f.lastDelete = in
+	return &dynamodb.DeleteItemOutput{}, nil
+}
+
+func (f *fakeDDB) UpdateItem(_ context.Context, in *dynamodb.UpdateItemInput, _ ...func(*dynamodb.Options)) (*dynamodb.UpdateItemOutput, error) {
+	f.lastUpdate = in
+	if f.updateErr != nil {
+		return nil, f.updateErr
+	}
+	return &dynamodb.UpdateItemOutput{}, nil
+}
+
+func s(v string) types.AttributeValue  { return &types.AttributeValueMemberS{Value: v} }
+func n(v string) types.AttributeValue  { return &types.AttributeValueMemberN{Value: v} }
+func strOf(av types.AttributeValue) string {
+	return av.(*types.AttributeValueMemberS).Value
+}
+
+// List must unmarshal a realistic ElectroDB-written item, ignoring the
+// __edb_e__/__edb_v__ meta attributes run.human's entity always writes.
+func TestListUnmarshalsElectroDBItem(t *testing.T) {
+	fake := &fakeDDB{queryOut: &dynamodb.QueryOutput{
+		Items: []map[string]types.AttributeValue{{
+			"pk":        s("$run#queue_otp"),
+			"sk":        s("$meshotppending_1#nodeid_!433d1cec"),
+			"__edb_e__": s("MeshOtpPending"),
+			"__edb_v__": s("1"),
+			"queue":     s("otp"),
+			"nodeId":    s("!433d1cec"),
+			"nodeNum":   n("1128078572"),
+			"code":      s("123456"),
+			"publicKey": s("0xabc123"),
+			"userId":    s("user-1"),
+			"attempts":  n("2"),
+			"createdAt": n("1784969443000"),
+		}},
+	}}
+	store := NewDynamoDBStoreWithClient(fake, "run-human-electro")
+
+	items, err := store.List(context.Background())
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("want 1 item, got %d", len(items))
+	}
+	it := items[0]
+	if it.NodeID != "!433d1cec" || it.NodeNum != 1128078572 || it.Code != "123456" ||
+		it.PublicKey != "0xabc123" || it.UserID != "user-1" || it.Attempts != 2 ||
+		it.CreatedAt != 1784969443000 {
+		t.Fatalf("bad unmarshal: %+v", it)
+	}
+	// Query shape: constant partition, sk prefix — never a Scan.
+	kc := *fake.lastQuery.KeyConditionExpression
+	if kc != "pk = :pk AND begins_with(sk, :skp)" {
+		t.Fatalf("bad key condition: %q", kc)
+	}
+	if strOf(fake.lastQuery.ExpressionAttributeValues[":pk"]) != "$run#queue_otp" {
+		t.Fatalf("bad :pk")
+	}
+}
+
+func TestDeleteComposesQueueKey(t *testing.T) {
+	fake := &fakeDDB{}
+	store := NewDynamoDBStoreWithClient(fake, "run-human-electro")
+	if err := store.Delete(context.Background(), "!433d1cec"); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if strOf(fake.lastDelete.Key["pk"]) != "$run#queue_otp" ||
+		strOf(fake.lastDelete.Key["sk"]) != "$meshotppending_1#nodeid_!433d1cec" {
+		t.Fatalf("bad delete key: %+v", fake.lastDelete.Key)
+	}
+}
+
+func TestMarkRadioCodeSentGuardedAndSwallowsConditionFailure(t *testing.T) {
+	fake := &fakeDDB{}
+	store := NewDynamoDBStoreWithClient(fake, "run-human-electro")
+
+	if err := store.MarkRadioCodeSent(context.Background(), 1128078572, 1784969443000); err != nil {
+		t.Fatalf("MarkRadioCodeSent: %v", err)
+	}
+	if strOf(fake.lastUpdate.Key["pk"]) != "$run#nodeid_!433d1cec" ||
+		strOf(fake.lastUpdate.Key["sk"]) != "$meshradio_1" {
+		t.Fatalf("bad radio key: %+v", fake.lastUpdate.Key)
+	}
+	if *fake.lastUpdate.ConditionExpression != "attribute_exists(pk)" {
+		t.Fatalf("missing orphan-row guard: %v", fake.lastUpdate.ConditionExpression)
+	}
+
+	// Deleted-radio race: conditional failure is silently OK.
+	fake.updateErr = &types.ConditionalCheckFailedException{}
+	if err := store.MarkRadioCodeSent(context.Background(), 1128078572, 1); err != nil {
+		t.Fatalf("conditional failure must be swallowed, got %v", err)
+	}
+
+	// Any other error propagates.
+	fake.updateErr = errors.New("throttled")
+	if err := store.MarkRadioCodeSent(context.Background(), 1128078572, 1); err == nil {
+		t.Fatal("real error must propagate")
+	}
+}

--- a/internal/otpqueue/types.go
+++ b/internal/otpqueue/types.go
@@ -1,0 +1,59 @@
+// Package otpqueue drains the MeshOtpPending delivery queue: run.human
+// enqueues a radio-verification code on manual add/resend, and the fleet's
+// poller (internal/app/fleet/otpsend.go) PKI-DMs it to the device, deletes the
+// item, and stamps codeSentAt on the MeshRadio row.
+//
+// Key strings are a LOCKED cross-language contract with run.human's ElectroDB
+// entities (mesh-otp-pending-key-parity.test.ts / mesh-radio-key-parity.test.ts
+// ↔ key_parity_test.go here). The live table has DDB TTL disabled, so expiry
+// is enforced by the poller via MaxAgeMs.
+package otpqueue
+
+import (
+	"context"
+	"fmt"
+)
+
+const (
+	queuePK       = "$run#queue_otp"
+	queueSKPrefix = "$meshotppending_1#nodeid_"
+
+	// MaxAgeMs: items older than this are reaped unsent (no DDB TTL on the
+	// live table). Matches the spec's 24 h.
+	MaxAgeMs = 24 * 60 * 60 * 1000
+
+	// MaxAttempts: give up on an item after this many failed publishes.
+	MaxAttempts = 10
+)
+
+func queueSK(nodeID string) string { return queueSKPrefix + nodeID }
+
+type radioKey struct{ PK, SK string }
+
+// meshRadioKey composes the byte-identical ElectroDB MeshRadio primary key —
+// the same contract keycache locks for pubkey reads; here it targets the
+// guarded codeSentAt stamp.
+func meshRadioKey(nodeNum uint32) radioKey {
+	return radioKey{PK: fmt.Sprintf("$run#nodeid_!%08x", nodeNum), SK: "$meshradio_1"}
+}
+
+// Item is one pending OTP delivery, as written by run.human's MeshOtpPending
+// entity. Unknown attributes (__edb_e__ etc.) are ignored on unmarshal.
+type Item struct {
+	NodeID    string `dynamodbav:"nodeId"`
+	NodeNum   uint32 `dynamodbav:"nodeNum"`
+	Code      string `dynamodbav:"code"`
+	PublicKey string `dynamodbav:"publicKey"` // "0x…" or "" when the user supplied none
+	UserID    string `dynamodbav:"userId"`
+	Attempts  int    `dynamodbav:"attempts"`
+	CreatedAt int64  `dynamodbav:"createdAt"` // epoch ms (run.human Date.now())
+}
+
+// Store is the queue surface the fleet poller consumes; DynamoDBStore is the
+// production implementation, tests use fakes.
+type Store interface {
+	List(ctx context.Context) ([]Item, error)
+	Delete(ctx context.Context, nodeID string) error
+	BumpAttempts(ctx context.Context, nodeID string, attempts int) error
+	MarkRadioCodeSent(ctx context.Context, nodeNum uint32, sentAtMs int64) error
+}


### PR DESCRIPTION
Drains run.human's MeshOtpPending DDB queue (locked key-parity contract) every 20s from the ghosts/fleet process and PKI-DMs the 6-digit verification code to the device from the NodeInfo (map) node identity, on the sender's own gateway PKI topic.

- internal/otpqueue: Query/Delete/BumpAttempts store + guarded codeSentAt stamp on the MeshRadio row (attribute_exists guard, ConditionalCheckFailed swallowed)
- internal/mqtt: NODEINFO-observed pubkey map + ObservedPubKey lookup (last-resort recipient key)
- internal/app/fleet: poller with expiry reap (24h, table TTL disabled), 10-attempt cap, resolution chain user-supplied → keycache → observed

Pairs with defcon.run.34 run.human changes (MeshOtpPending entity, enqueue on add/resend, honest delivery-state UI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)