### PR TITLE
feat: post-flash welcome DM (queue classification + proof-of-life re-flush)

### DIFF
--- a/internal/app/fleet/otpsend.go
+++ b/internal/app/fleet/otpsend.go
@@ -26,6 +26,11 @@ type otpSendDeps interface {
 	// user-supplied on the item → authoritative MeshRadio row → NODEINFO-observed.
 	ResolvePubKeyHex(item otpqueue.Item) (string, bool)
 	SendCode(toNodeNum uint32, pubKeyHex, code string) error
+	// SendWelcome publishes the welcome text immediately AND hands the
+	// byte-identical envelope to the fleet's proof-of-life pending store, so a
+	// radio that comes online within the pending TTL still receives it (the
+	// device's packet-id dedup makes the duplicate invisible).
+	SendWelcome(item otpqueue.WelcomeItem, pubKeyHex string) error
 	NowMs() int64
 }
 
@@ -34,16 +39,16 @@ type otpSendDeps interface {
 // send OK → delete + stamp codeSentAt; send failed → bump attempts and retry
 // next pass.
 func processOtpQueue(ctx context.Context, deps otpSendDeps, store otpqueue.Store, logger *log.Logger) {
-	items, err := store.List(ctx)
+	items, welcomes, err := store.List(ctx)
 	if err != nil {
 		logger.Errorf("otp: queue list failed: %v", err)
 		return
 	}
-	if len(items) == 0 {
+	if len(items) == 0 && len(welcomes) == 0 {
 		return
 	}
 
-	var sent, waiting, reaped, failed int
+	var sent, welcome, waiting, reaped, failed int
 	for _, it := range items {
 		switch {
 		case deps.NowMs()-it.CreatedAt > otpqueue.MaxAgeMs:
@@ -81,7 +86,45 @@ func processOtpQueue(ctx context.Context, deps otpSendDeps, store otpqueue.Store
 			logger.Infof("otp: verification code delivered to %s", it.NodeID)
 		}
 	}
-	logger.Infof("otp: pass done sent=%d waiting=%d reaped=%d failed=%d", sent, waiting, reaped, failed)
+
+	// Welcome items: same lifecycle gates, no codeSentAt stamp (nothing reads
+	// it), delivery via SendWelcome's immediate-publish + proof-of-life re-flush.
+	for _, w := range welcomes {
+		switch {
+		case deps.NowMs()-w.CreatedAt > otpqueue.MaxAgeMs:
+			reaped++
+			if err := store.DeleteWelcome(ctx, w.NodeID); err != nil {
+				logger.Errorf("otp: reap expired welcome %s failed: %v", w.NodeID, err)
+			}
+		case w.Attempts >= otpqueue.MaxAttempts:
+			reaped++
+			logger.Errorf("otp: giving up on welcome %s after %d failed publishes", w.NodeID, w.Attempts)
+			if err := store.DeleteWelcome(ctx, w.NodeID); err != nil {
+				logger.Errorf("otp: reap capped welcome %s failed: %v", w.NodeID, err)
+			}
+		default:
+			pubKey, ok := deps.ResolvePubKeyHex(otpqueue.Item{NodeID: w.NodeID, NodeNum: w.NodeNum})
+			if !ok {
+				waiting++
+				continue
+			}
+			if err := deps.SendWelcome(w, pubKey); err != nil {
+				failed++
+				logger.Errorf("otp: welcome to %s failed (attempt %d): %v", w.NodeID, w.Attempts+1, err)
+				if err := store.BumpWelcomeAttempts(ctx, w.NodeID, w.Attempts+1); err != nil {
+					logger.Errorf("otp: bump welcome %s failed: %v", w.NodeID, err)
+				}
+				continue
+			}
+			welcome++
+			if err := store.DeleteWelcome(ctx, w.NodeID); err != nil {
+				logger.Errorf("otp: delete sent welcome %s failed (device may see a duplicate): %v", w.NodeID, err)
+			}
+			logger.Infof("otp: welcome delivered to %s", w.NodeID)
+		}
+	}
+
+	logger.Infof("otp: pass done sent=%d welcome=%d waiting=%d reaped=%d failed=%d", sent, welcome, waiting, reaped, failed)
 }
 
 // pkiTopicFor derives the SENDER's gateway PKI topic from the NodeInfo channel
@@ -123,30 +166,52 @@ func (d *fleetOtpDeps) ResolvePubKeyHex(item otpqueue.Item) (string, bool) {
 	return client.ObservedPubKey(item.NodeNum)
 }
 
-func (d *fleetOtpDeps) SendCode(toNodeNum uint32, pubKeyHex, code string) error {
+// buildAndPublish PKI-encrypts text from the NodeInfo (map) identity to the
+// device and publishes it on the sender's gateway topic. Returns everything a
+// caller needs for a byte-identical re-send.
+func (d *fleetOtpDeps) buildAndPublish(toNodeNum uint32, pubKeyHex, text string) (sender uint32, topic string, envelope []byte, err error) {
 	cfg := d.f.Config
 	client := d.f.MqttClient[0]
 
-	sender, err := parseNodeID(cfg.NodeInfo.ClientId)
+	sender, err = parseNodeID(cfg.NodeInfo.ClientId)
 	if err != nil {
-		return err
+		return 0, "", nil, err
 	}
 	senderPriv, err := client.ParseHexKey(cfg.NodeInfo.PKI.PrivateKey)
 	if err != nil {
-		return fmt.Errorf("nodeinfo private key: %w", err)
+		return 0, "", nil, fmt.Errorf("nodeinfo private key: %w", err)
 	}
 	recipientPub, err := client.ParseHexKey(pubKeyHex)
 	if err != nil {
-		return fmt.Errorf("recipient pubkey: %w", err)
+		return 0, "", nil, fmt.Errorf("recipient pubkey: %w", err)
 	}
 
-	payload := fmt.Sprintf("run.defcon.run radio verification code: %s", code)
-	envelope, err := client.BuildPKIMessage(sender, toNodeNum,
-		meshtastic.PortNum_TEXT_MESSAGE_APP, []byte(payload), senderPriv, recipientPub)
+	envelope, err = client.BuildPKIMessage(sender, toNodeNum,
+		meshtastic.PortNum_TEXT_MESSAGE_APP, []byte(text), senderPriv, recipientPub)
+	if err != nil {
+		return 0, "", nil, err
+	}
+	topic = pkiTopicFor(cfg.NodeInfo.Topic, sender)
+	return sender, topic, envelope, client.PublishEnvelopeBytes(topic, envelope)
+}
+
+func (d *fleetOtpDeps) SendCode(toNodeNum uint32, pubKeyHex, code string) error {
+	_, _, _, err := d.buildAndPublish(toNodeNum, pubKeyHex,
+		fmt.Sprintf("run.defcon.run radio verification code: %s", code))
+	return err
+}
+
+func (d *fleetOtpDeps) SendWelcome(item otpqueue.WelcomeItem, pubKeyHex string) error {
+	sender, topic, envelope, err := d.buildAndPublish(item.NodeNum, pubKeyHex, item.Message)
 	if err != nil {
 		return err
 	}
-	return client.PublishEnvelopeBytes(pkiTopicFor(cfg.NodeInfo.Topic, sender), envelope)
+	// Proof-of-life re-flush: the radio may still be rebooting/pairing after
+	// the flash. Queue the SAME bytes; the next transmission from the node
+	// (within the pending TTL) re-publishes them — invisible duplicate if the
+	// first copy landed (packet-id dedup), first delivery if it didn't.
+	d.f.queuePendingReply(0, sender, item.NodeNum, topic, "welcome", envelope)
+	return nil
 }
 
 func (d *fleetOtpDeps) NowMs() int64 { return time.Now().UnixMilli() }

--- a/internal/app/fleet/otpsend_test.go
+++ b/internal/app/fleet/otpsend_test.go
@@ -17,18 +17,31 @@ func testLogger() *log.Logger {
 }
 
 type fakeOtpStore struct {
-	items    []otpqueue.Item
-	deleted  []string
-	bumped   map[string]int
-	marked   []uint32
-	listErr  error
+	items          []otpqueue.Item
+	welcomes       []otpqueue.WelcomeItem
+	deleted        []string
+	welcomeDeleted []string
+	bumped         map[string]int
+	welcomeBumped  map[string]int
+	marked         []uint32
+	listErr        error
 }
 
 func newFakeOtpStore(items ...otpqueue.Item) *fakeOtpStore {
-	return &fakeOtpStore{items: items, bumped: map[string]int{}}
+	return &fakeOtpStore{items: items, bumped: map[string]int{}, welcomeBumped: map[string]int{}}
 }
 
-func (f *fakeOtpStore) List(context.Context) ([]otpqueue.Item, error) { return f.items, f.listErr }
+func (f *fakeOtpStore) List(context.Context) ([]otpqueue.Item, []otpqueue.WelcomeItem, error) {
+	return f.items, f.welcomes, f.listErr
+}
+func (f *fakeOtpStore) DeleteWelcome(_ context.Context, nodeID string) error {
+	f.welcomeDeleted = append(f.welcomeDeleted, nodeID)
+	return nil
+}
+func (f *fakeOtpStore) BumpWelcomeAttempts(_ context.Context, nodeID string, attempts int) error {
+	f.welcomeBumped[nodeID] = attempts
+	return nil
+}
 func (f *fakeOtpStore) Delete(_ context.Context, nodeID string) error {
 	f.deleted = append(f.deleted, nodeID)
 	return nil
@@ -43,10 +56,12 @@ func (f *fakeOtpStore) MarkRadioCodeSent(_ context.Context, nodeNum uint32, _ in
 }
 
 type fakeOtpDeps struct {
-	pubkeys map[uint32]string
-	sendErr error
-	sent    []uint32
-	nowMs   int64
+	pubkeys      map[uint32]string
+	sendErr      error
+	sent         []uint32
+	welcomeSent  []string // messages, in order
+	welcomeErr   error
+	nowMs        int64
 }
 
 func (f *fakeOtpDeps) ResolvePubKeyHex(item otpqueue.Item) (string, bool) {
@@ -63,7 +78,81 @@ func (f *fakeOtpDeps) SendCode(toNodeNum uint32, pubKeyHex, code string) error {
 	f.sent = append(f.sent, toNodeNum)
 	return nil
 }
+func (f *fakeOtpDeps) SendWelcome(item otpqueue.WelcomeItem, _ string) error {
+	if f.welcomeErr != nil {
+		return f.welcomeErr
+	}
+	f.welcomeSent = append(f.welcomeSent, item.Message)
+	return nil
+}
 func (f *fakeOtpDeps) NowMs() int64 { return f.nowMs }
+
+func welcomeItem(nodeID string, nodeNum uint32, createdAt int64, attempts int) otpqueue.WelcomeItem {
+	return otpqueue.WelcomeItem{NodeID: nodeID, NodeNum: nodeNum, Message: "Welcome!", CreatedAt: createdAt, Attempts: attempts}
+}
+
+func TestWelcomeSuccessSendsAndDeletes(t *testing.T) {
+	store := newFakeOtpStore()
+	store.welcomes = []otpqueue.WelcomeItem{welcomeItem("!433d1cec", 1128078572, nowMs, 0)}
+	deps := &fakeOtpDeps{nowMs: nowMs, pubkeys: map[uint32]string{1128078572: "0xkey"}}
+
+	processOtpQueue(context.Background(), deps, store, testLogger())
+
+	if len(deps.welcomeSent) != 1 || deps.welcomeSent[0] != "Welcome!" {
+		t.Fatalf("expected one welcome send: %+v", deps.welcomeSent)
+	}
+	if len(store.welcomeDeleted) != 1 || store.welcomeDeleted[0] != "!433d1cec" {
+		t.Fatalf("sent welcome must be deleted: %+v", store.welcomeDeleted)
+	}
+	if len(store.marked) != 0 {
+		t.Fatal("welcome must NOT stamp codeSentAt")
+	}
+}
+
+func TestWelcomeNoPubkeyStaysQueued(t *testing.T) {
+	store := newFakeOtpStore()
+	store.welcomes = []otpqueue.WelcomeItem{welcomeItem("!433d1cec", 1128078572, nowMs, 0)}
+	deps := &fakeOtpDeps{nowMs: nowMs}
+
+	processOtpQueue(context.Background(), deps, store, testLogger())
+
+	if len(deps.welcomeSent) != 0 || len(store.welcomeDeleted) != 0 || len(store.welcomeBumped) != 0 {
+		t.Fatal("keyless welcome must be left untouched")
+	}
+}
+
+func TestWelcomeFailureBumpsAndSurvives(t *testing.T) {
+	store := newFakeOtpStore()
+	store.welcomes = []otpqueue.WelcomeItem{welcomeItem("!433d1cec", 1128078572, nowMs, 4)}
+	deps := &fakeOtpDeps{nowMs: nowMs, pubkeys: map[uint32]string{1128078572: "0xkey"}, welcomeErr: errors.New("broker down")}
+
+	processOtpQueue(context.Background(), deps, store, testLogger())
+
+	if len(store.welcomeDeleted) != 0 {
+		t.Fatal("failed welcome must survive")
+	}
+	if store.welcomeBumped["!433d1cec"] != 5 {
+		t.Fatalf("welcome attempts must bump to 5: %+v", store.welcomeBumped)
+	}
+}
+
+func TestWelcomeExpiredAndCappedReap(t *testing.T) {
+	store := newFakeOtpStore()
+	store.welcomes = []otpqueue.WelcomeItem{
+		welcomeItem("!00000001", 1, nowMs-otpqueue.MaxAgeMs-1, 0),
+		welcomeItem("!00000002", 2, nowMs, otpqueue.MaxAttempts),
+	}
+	deps := &fakeOtpDeps{nowMs: nowMs, pubkeys: map[uint32]string{1: "0xk", 2: "0xk"}}
+
+	processOtpQueue(context.Background(), deps, store, testLogger())
+
+	if len(deps.welcomeSent) != 0 {
+		t.Fatal("reaped welcomes must not send")
+	}
+	if len(store.welcomeDeleted) != 2 {
+		t.Fatalf("both welcomes must be reaped: %+v", store.welcomeDeleted)
+	}
+}
 
 func item(nodeID string, nodeNum uint32, createdAt int64, attempts int) otpqueue.Item {
 	return otpqueue.Item{NodeID: nodeID, NodeNum: nodeNum, Code: "123456", CreatedAt: createdAt, Attempts: attempts}

--- a/internal/otpqueue/key_parity_test.go
+++ b/internal/otpqueue/key_parity_test.go
@@ -18,6 +18,16 @@ func TestQueueKeyParity(t *testing.T) {
 	}
 }
 
+// LOCKED ↔ run.human's mesh-welcome-pending-key-parity.test.ts.
+func TestWelcomeKeyParity(t *testing.T) {
+	if got := welcomeSK("!433d1cec"); got != "$meshwelcomepending_1#nodeid_!433d1cec" {
+		t.Fatalf("welcome sk drifted: %q", got)
+	}
+	if welcomeSKPrefix != "$meshwelcomepending_1#nodeid_" {
+		t.Fatalf("welcome sk prefix drifted: %q", welcomeSKPrefix)
+	}
+}
+
 // Mirrors keycache's parity lock on the MeshRadio primary key — the poller
 // stamps codeSentAt onto this row after a successful send.
 func TestMeshRadioKeyParity(t *testing.T) {

--- a/internal/otpqueue/store.go
+++ b/internal/otpqueue/store.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
@@ -65,38 +66,53 @@ func (s *DynamoDBStore) queueKey(nodeID string) map[string]types.AttributeValue 
 	}
 }
 
-// List returns every pending OTP delivery. The queue partition is tiny, but
-// pagination is followed anyway.
-func (s *DynamoDBStore) List(ctx context.Context) ([]Item, error) {
+// List returns every pending delivery in the queue partition — OTP items and
+// welcome items, classified by sk prefix. Unknown prefixes are skipped
+// (forward compatibility). The partition is tiny; pagination is followed
+// anyway.
+func (s *DynamoDBStore) List(ctx context.Context) ([]Item, []WelcomeItem, error) {
 	var items []Item
+	var welcomes []WelcomeItem
 	var startKey map[string]types.AttributeValue
 
 	for {
 		out, err := s.client.Query(ctx, &dynamodb.QueryInput{
 			TableName:              aws.String(s.tableName),
-			KeyConditionExpression: aws.String("pk = :pk AND begins_with(sk, :skp)"),
+			KeyConditionExpression: aws.String("pk = :pk"),
 			ExpressionAttributeValues: map[string]types.AttributeValue{
-				":pk":  &types.AttributeValueMemberS{Value: queuePK},
-				":skp": &types.AttributeValueMemberS{Value: queueSKPrefix},
+				":pk": &types.AttributeValueMemberS{Value: queuePK},
 			},
 			ExclusiveStartKey: startKey,
 		})
 		if err != nil {
-			return nil, fmt.Errorf("otpqueue query: %w", err)
+			return nil, nil, fmt.Errorf("otpqueue query: %w", err)
 		}
 		for _, raw := range out.Items {
-			var it Item
-			if err := attributevalue.UnmarshalMap(raw, &it); err != nil {
-				return nil, fmt.Errorf("otpqueue unmarshal: %w", err)
+			skAttr, ok := raw["sk"].(*types.AttributeValueMemberS)
+			if !ok {
+				continue
 			}
-			items = append(items, it)
+			switch {
+			case strings.HasPrefix(skAttr.Value, queueSKPrefix):
+				var it Item
+				if err := attributevalue.UnmarshalMap(raw, &it); err != nil {
+					return nil, nil, fmt.Errorf("otpqueue unmarshal: %w", err)
+				}
+				items = append(items, it)
+			case strings.HasPrefix(skAttr.Value, welcomeSKPrefix):
+				var w WelcomeItem
+				if err := attributevalue.UnmarshalMap(raw, &w); err != nil {
+					return nil, nil, fmt.Errorf("otpqueue welcome unmarshal: %w", err)
+				}
+				welcomes = append(welcomes, w)
+			}
 		}
 		if len(out.LastEvaluatedKey) == 0 {
 			break
 		}
 		startKey = out.LastEvaluatedKey
 	}
-	return items, nil
+	return items, welcomes, nil
 }
 
 // Delete removes a queue item (idempotent at the DynamoDB level).
@@ -123,6 +139,40 @@ func (s *DynamoDBStore) BumpAttempts(ctx context.Context, nodeID string, attempt
 	})
 	if err != nil {
 		return fmt.Errorf("otpqueue bump %s: %w", nodeID, err)
+	}
+	return nil
+}
+
+// DeleteWelcome removes a welcome queue item (idempotent).
+func (s *DynamoDBStore) DeleteWelcome(ctx context.Context, nodeID string) error {
+	_, err := s.client.DeleteItem(ctx, &dynamodb.DeleteItemInput{
+		TableName: aws.String(s.tableName),
+		Key: map[string]types.AttributeValue{
+			"pk": &types.AttributeValueMemberS{Value: queuePK},
+			"sk": &types.AttributeValueMemberS{Value: welcomeSK(nodeID)},
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("otpqueue delete welcome %s: %w", nodeID, err)
+	}
+	return nil
+}
+
+// BumpWelcomeAttempts records a failed publish attempt on a welcome item.
+func (s *DynamoDBStore) BumpWelcomeAttempts(ctx context.Context, nodeID string, attempts int) error {
+	_, err := s.client.UpdateItem(ctx, &dynamodb.UpdateItemInput{
+		TableName: aws.String(s.tableName),
+		Key: map[string]types.AttributeValue{
+			"pk": &types.AttributeValueMemberS{Value: queuePK},
+			"sk": &types.AttributeValueMemberS{Value: welcomeSK(nodeID)},
+		},
+		UpdateExpression: aws.String("SET attempts = :a"),
+		ExpressionAttributeValues: map[string]types.AttributeValue{
+			":a": &types.AttributeValueMemberN{Value: fmt.Sprintf("%d", attempts)},
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("otpqueue bump welcome %s: %w", nodeID, err)
 	}
 	return nil
 }

--- a/internal/otpqueue/store_test.go
+++ b/internal/otpqueue/store_test.go
@@ -45,47 +45,81 @@ func strOf(av types.AttributeValue) string {
 	return av.(*types.AttributeValueMemberS).Value
 }
 
-// List must unmarshal a realistic ElectroDB-written item, ignoring the
-// __edb_e__/__edb_v__ meta attributes run.human's entity always writes.
-func TestListUnmarshalsElectroDBItem(t *testing.T) {
+// List must classify a MIXED partition — otp + welcome + unknown sk prefixes
+// in one Query page — and ignore ElectroDB's __edb_e__/__edb_v__ meta noise.
+func TestListClassifiesMixedPartition(t *testing.T) {
 	fake := &fakeDDB{queryOut: &dynamodb.QueryOutput{
-		Items: []map[string]types.AttributeValue{{
-			"pk":        s("$run#queue_otp"),
-			"sk":        s("$meshotppending_1#nodeid_!433d1cec"),
-			"__edb_e__": s("MeshOtpPending"),
-			"__edb_v__": s("1"),
-			"queue":     s("otp"),
-			"nodeId":    s("!433d1cec"),
-			"nodeNum":   n("1128078572"),
-			"code":      s("123456"),
-			"publicKey": s("0xabc123"),
-			"userId":    s("user-1"),
-			"attempts":  n("2"),
-			"createdAt": n("1784969443000"),
-		}},
+		Items: []map[string]types.AttributeValue{
+			{
+				"pk":        s("$run#queue_otp"),
+				"sk":        s("$meshotppending_1#nodeid_!433d1cec"),
+				"__edb_e__": s("MeshOtpPending"),
+				"__edb_v__": s("1"),
+				"queue":     s("otp"),
+				"nodeId":    s("!433d1cec"),
+				"nodeNum":   n("1128078572"),
+				"code":      s("123456"),
+				"publicKey": s("0xabc123"),
+				"userId":    s("user-1"),
+				"attempts":  n("2"),
+				"createdAt": n("1784969443000"),
+			},
+			{
+				"pk":        s("$run#queue_otp"),
+				"sk":        s("$meshwelcomepending_1#nodeid_!433d1cec"),
+				"__edb_e__": s("MeshWelcomePending"),
+				"__edb_v__": s("1"),
+				"queue":     s("otp"),
+				"nodeId":    s("!433d1cec"),
+				"nodeNum":   n("1128078572"),
+				"message":   s("Welcome to defcon.run, Kurt!"),
+				"userId":    s("user-1"),
+				"attempts":  n("0"),
+				"createdAt": n("1784969443001"),
+			},
+			{
+				"pk": s("$run#queue_otp"),
+				"sk": s("$somethingelse_1#nodeid_!433d1cec"),
+			},
+		},
 	}}
 	store := NewDynamoDBStoreWithClient(fake, "run-human-electro")
 
-	items, err := store.List(context.Background())
+	items, welcomes, err := store.List(context.Background())
 	if err != nil {
 		t.Fatalf("List: %v", err)
 	}
-	if len(items) != 1 {
-		t.Fatalf("want 1 item, got %d", len(items))
+	if len(items) != 1 || len(welcomes) != 1 {
+		t.Fatalf("want 1 otp + 1 welcome, got %d/%d", len(items), len(welcomes))
 	}
 	it := items[0]
 	if it.NodeID != "!433d1cec" || it.NodeNum != 1128078572 || it.Code != "123456" ||
 		it.PublicKey != "0xabc123" || it.UserID != "user-1" || it.Attempts != 2 ||
 		it.CreatedAt != 1784969443000 {
-		t.Fatalf("bad unmarshal: %+v", it)
+		t.Fatalf("bad otp unmarshal: %+v", it)
 	}
-	// Query shape: constant partition, sk prefix — never a Scan.
-	kc := *fake.lastQuery.KeyConditionExpression
-	if kc != "pk = :pk AND begins_with(sk, :skp)" {
+	w := welcomes[0]
+	if w.NodeID != "!433d1cec" || w.NodeNum != 1128078572 ||
+		w.Message != "Welcome to defcon.run, Kurt!" || w.Attempts != 0 {
+		t.Fatalf("bad welcome unmarshal: %+v", w)
+	}
+	// Query shape: whole constant partition — never a Scan, no sk condition.
+	if kc := *fake.lastQuery.KeyConditionExpression; kc != "pk = :pk" {
 		t.Fatalf("bad key condition: %q", kc)
 	}
 	if strOf(fake.lastQuery.ExpressionAttributeValues[":pk"]) != "$run#queue_otp" {
 		t.Fatalf("bad :pk")
+	}
+}
+
+func TestDeleteWelcomeComposesWelcomeKey(t *testing.T) {
+	fake := &fakeDDB{}
+	store := NewDynamoDBStoreWithClient(fake, "run-human-electro")
+	if err := store.DeleteWelcome(context.Background(), "!433d1cec"); err != nil {
+		t.Fatalf("DeleteWelcome: %v", err)
+	}
+	if strOf(fake.lastDelete.Key["sk"]) != "$meshwelcomepending_1#nodeid_!433d1cec" {
+		t.Fatalf("bad welcome delete key: %+v", fake.lastDelete.Key)
 	}
 }
 

--- a/internal/otpqueue/types.go
+++ b/internal/otpqueue/types.go
@@ -17,6 +17,9 @@ import (
 const (
 	queuePK       = "$run#queue_otp"
 	queueSKPrefix = "$meshotppending_1#nodeid_"
+	// Welcome DMs share the physical partition; the sk prefix is the kind
+	// discriminator (LOCKED ↔ run.human mesh-welcome-pending parity test).
+	welcomeSKPrefix = "$meshwelcomepending_1#nodeid_"
 
 	// MaxAgeMs: items older than this are reaped unsent (no DDB TTL on the
 	// live table). Matches the spec's 24 h.
@@ -26,7 +29,8 @@ const (
 	MaxAttempts = 10
 )
 
-func queueSK(nodeID string) string { return queueSKPrefix + nodeID }
+func queueSK(nodeID string) string   { return queueSKPrefix + nodeID }
+func welcomeSK(nodeID string) string { return welcomeSKPrefix + nodeID }
 
 type radioKey struct{ PK, SK string }
 
@@ -49,11 +53,25 @@ type Item struct {
 	CreatedAt int64  `dynamodbav:"createdAt"` // epoch ms (run.human Date.now())
 }
 
+// WelcomeItem is one pending post-flash welcome DM, as written by run.human's
+// MeshWelcomePending entity (same partition, welcome sk prefix).
+type WelcomeItem struct {
+	NodeID    string `dynamodbav:"nodeId"`
+	NodeNum   uint32 `dynamodbav:"nodeNum"`
+	Message   string `dynamodbav:"message"`
+	UserID    string `dynamodbav:"userId"`
+	Attempts  int    `dynamodbav:"attempts"`
+	CreatedAt int64  `dynamodbav:"createdAt"`
+}
+
 // Store is the queue surface the fleet poller consumes; DynamoDBStore is the
-// production implementation, tests use fakes.
+// production implementation, tests use fakes. List returns BOTH kinds from
+// the one partition Query; unknown sk prefixes are skipped.
 type Store interface {
-	List(ctx context.Context) ([]Item, error)
+	List(ctx context.Context) ([]Item, []WelcomeItem, error)
 	Delete(ctx context.Context, nodeID string) error
 	BumpAttempts(ctx context.Context, nodeID string, attempts int) error
 	MarkRadioCodeSent(ctx context.Context, nodeNum uint32, sentAtMs int64) error
+	DeleteWelcome(ctx context.Context, nodeID string) error
+	BumpWelcomeAttempts(ctx context.Context, nodeID string, attempts int) error
 }


### PR DESCRIPTION
Welcome items share the OTP queue partition (sk-prefix classified); poller sends them via the map-node PKI path, then queues the byte-identical envelope for proof-of-life re-flush (packet-id dedup makes duplicates invisible). Pairs with defcon.run.34 registration-route enqueue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)