### PR TITLE
fix: hold welcome DMs until the radio is alive on the mesh

### DIFF
--- a/internal/app/fleet/cmd.go
+++ b/internal/app/fleet/cmd.go
@@ -57,6 +57,15 @@ type FleetCmd struct {
 	Pending    map[uint32][]*pendingReply
 	PendingMux sync.Mutex
 
+	// LastSeen records the wall-clock of each node's most recent transmission
+	// (fed by onNodeSeen). The welcome-DM poller gates on it: a welcome only
+	// sends while the radio is provably alive on the mesh, because a PKI DM
+	// published into a dead session simply evaporates (observed 2026-07-27:
+	// welcomes published 16-31 min before the app's first MQTT connect were
+	// lost — the 10-min pending re-flush had already expired).
+	LastSeen    map[uint32]time.Time
+	LastSeenMux sync.RWMutex
+
 	// ReplyNextAt staggers consecutive one-shot reply lines to the same
 	// recipient (see sendPKIReplyReliable); keyed by recipient node num.
 	ReplyNextAt    map[uint32]time.Time
@@ -183,6 +192,7 @@ func NewFleets(c *config.Config) (f *FleetCmd) {
 	}
 
 	f.Pending = make(map[uint32][]*pendingReply)
+	f.LastSeen = make(map[uint32]time.Time)
 	f.ReplyNextAt = make(map[uint32]time.Time)
 
 	f.KeyResolver = buildKeyResolver(c)
@@ -641,9 +651,25 @@ func (n *FleetCmd) queuePendingReply(toFleetIdx int, ghost, to uint32, topic, te
 	})
 }
 
+// markNodeSeen stamps the node's liveness clock (see LastSeen).
+func (n *FleetCmd) markNodeSeen(node uint32) {
+	n.LastSeenMux.Lock()
+	n.LastSeen[node] = time.Now()
+	n.LastSeenMux.Unlock()
+}
+
+// lastSeenWithin reports whether the node transmitted within window.
+func (n *FleetCmd) lastSeenWithin(node uint32, window time.Duration) bool {
+	n.LastSeenMux.RLock()
+	t, ok := n.LastSeen[node]
+	n.LastSeenMux.RUnlock()
+	return ok && time.Since(t) <= window
+}
+
 // onNodeSeen is the store-and-forward trigger: any transmission from a node
 // proves it is connected, so flush whatever it may have missed.
 func (n *FleetCmd) onNodeSeen(node uint32) {
+	n.markNodeSeen(node)
 	n.PendingMux.Lock()
 	entries, ok := n.Pending[node]
 	if !ok {

--- a/internal/app/fleet/otpsend.go
+++ b/internal/app/fleet/otpsend.go
@@ -31,8 +31,19 @@ type otpSendDeps interface {
 	// radio that comes online within the pending TTL still receives it (the
 	// device's packet-id dedup makes the duplicate invisible).
 	SendWelcome(item otpqueue.WelcomeItem, pubKeyHex string) error
+	// NodeAliveNow reports whether the radio transmitted recently. Welcomes
+	// only send while true: a PKI DM published into a dead session evaporates
+	// (2026-07-27 field failure — app pairing finished 16-31 min after the
+	// publish, past the 10-min pending re-flush TTL, and both welcomes were
+	// lost). The queue item waits, up to its 24 h life, for first contact.
+	NodeAliveNow(nodeNum uint32) bool
 	NowMs() int64
 }
+
+// welcomeAliveWindow: how recently a node must have transmitted to count as
+// reachable for a welcome send. Generous enough to bridge broadcast gaps,
+// tight enough that "alive" still means an active session.
+const welcomeAliveWindow = 5 * time.Minute
 
 // processOtpQueue runs one poll pass. Item lifecycle: expired or attempt-capped
 // → reap; no pubkey yet → leave queued (the radio may announce NODEINFO later);
@@ -103,6 +114,12 @@ func processOtpQueue(ctx context.Context, deps otpSendDeps, store otpqueue.Store
 				logger.Errorf("otp: reap capped welcome %s failed: %v", w.NodeID, err)
 			}
 		default:
+			// Hold the welcome until the radio is provably on the mesh right
+			// now — first contact after flashing may be many minutes out.
+			if !deps.NodeAliveNow(w.NodeNum) {
+				waiting++
+				continue
+			}
 			pubKey, ok := deps.ResolvePubKeyHex(otpqueue.Item{NodeID: w.NodeID, NodeNum: w.NodeNum})
 			if !ok {
 				waiting++
@@ -212,6 +229,10 @@ func (d *fleetOtpDeps) SendWelcome(item otpqueue.WelcomeItem, pubKeyHex string) 
 	// first copy landed (packet-id dedup), first delivery if it didn't.
 	d.f.queuePendingReply(0, sender, item.NodeNum, topic, "welcome", envelope)
 	return nil
+}
+
+func (d *fleetOtpDeps) NodeAliveNow(nodeNum uint32) bool {
+	return d.f.lastSeenWithin(nodeNum, welcomeAliveWindow)
 }
 
 func (d *fleetOtpDeps) NowMs() int64 { return time.Now().UnixMilli() }

--- a/internal/app/fleet/otpsend_test.go
+++ b/internal/app/fleet/otpsend_test.go
@@ -56,13 +56,16 @@ func (f *fakeOtpStore) MarkRadioCodeSent(_ context.Context, nodeNum uint32, _ in
 }
 
 type fakeOtpDeps struct {
-	pubkeys      map[uint32]string
-	sendErr      error
-	sent         []uint32
-	welcomeSent  []string // messages, in order
-	welcomeErr   error
-	nowMs        int64
+	pubkeys     map[uint32]string
+	sendErr     error
+	sent        []uint32
+	welcomeSent []string // messages, in order
+	welcomeErr  error
+	alive       map[uint32]bool
+	nowMs       int64
 }
+
+func (f *fakeOtpDeps) NodeAliveNow(nodeNum uint32) bool { return f.alive[nodeNum] }
 
 func (f *fakeOtpDeps) ResolvePubKeyHex(item otpqueue.Item) (string, bool) {
 	if item.PublicKey != "" {
@@ -91,10 +94,30 @@ func welcomeItem(nodeID string, nodeNum uint32, createdAt int64, attempts int) o
 	return otpqueue.WelcomeItem{NodeID: nodeID, NodeNum: nodeNum, Message: "Welcome!", CreatedAt: createdAt, Attempts: attempts}
 }
 
+func TestWelcomeHeldUntilNodeAlive(t *testing.T) {
+	store := newFakeOtpStore()
+	store.welcomes = []otpqueue.WelcomeItem{welcomeItem("!433d1cec", 1128078572, nowMs, 0)}
+	// Pubkey known but node NOT alive — the 2026-07-27 field failure shape.
+	deps := &fakeOtpDeps{nowMs: nowMs, pubkeys: map[uint32]string{1128078572: "0xkey"}}
+
+	processOtpQueue(context.Background(), deps, store, testLogger())
+
+	if len(deps.welcomeSent) != 0 || len(store.welcomeDeleted) != 0 || len(store.welcomeBumped) != 0 {
+		t.Fatal("welcome to a dead session must wait, not send")
+	}
+
+	// Node comes alive → next pass delivers.
+	deps.alive = map[uint32]bool{1128078572: true}
+	processOtpQueue(context.Background(), deps, store, testLogger())
+	if len(deps.welcomeSent) != 1 || len(store.welcomeDeleted) != 1 {
+		t.Fatalf("welcome must send once node is alive: sent=%v deleted=%v", deps.welcomeSent, store.welcomeDeleted)
+	}
+}
+
 func TestWelcomeSuccessSendsAndDeletes(t *testing.T) {
 	store := newFakeOtpStore()
 	store.welcomes = []otpqueue.WelcomeItem{welcomeItem("!433d1cec", 1128078572, nowMs, 0)}
-	deps := &fakeOtpDeps{nowMs: nowMs, pubkeys: map[uint32]string{1128078572: "0xkey"}}
+	deps := &fakeOtpDeps{nowMs: nowMs, pubkeys: map[uint32]string{1128078572: "0xkey"}, alive: map[uint32]bool{1128078572: true}}
 
 	processOtpQueue(context.Background(), deps, store, testLogger())
 
@@ -112,7 +135,7 @@ func TestWelcomeSuccessSendsAndDeletes(t *testing.T) {
 func TestWelcomeNoPubkeyStaysQueued(t *testing.T) {
 	store := newFakeOtpStore()
 	store.welcomes = []otpqueue.WelcomeItem{welcomeItem("!433d1cec", 1128078572, nowMs, 0)}
-	deps := &fakeOtpDeps{nowMs: nowMs}
+	deps := &fakeOtpDeps{nowMs: nowMs, alive: map[uint32]bool{1128078572: true}}
 
 	processOtpQueue(context.Background(), deps, store, testLogger())
 
@@ -124,7 +147,7 @@ func TestWelcomeNoPubkeyStaysQueued(t *testing.T) {
 func TestWelcomeFailureBumpsAndSurvives(t *testing.T) {
 	store := newFakeOtpStore()
 	store.welcomes = []otpqueue.WelcomeItem{welcomeItem("!433d1cec", 1128078572, nowMs, 4)}
-	deps := &fakeOtpDeps{nowMs: nowMs, pubkeys: map[uint32]string{1128078572: "0xkey"}, welcomeErr: errors.New("broker down")}
+	deps := &fakeOtpDeps{nowMs: nowMs, pubkeys: map[uint32]string{1128078572: "0xkey"}, alive: map[uint32]bool{1128078572: true}, welcomeErr: errors.New("broker down")}
 
 	processOtpQueue(context.Background(), deps, store, testLogger())
 


### PR DESCRIPTION
Field failure 2026-07-27: welcomes published into dead sessions were lost (first app connect came 16-31 min later, past the pending re-flush TTL). Adds a LastSeen liveness clock (fed by onNodeSeen) and gates welcome sends on transmission within 5 min; items wait up to 24h for first contact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)